### PR TITLE
fix: for Homebase 3 & S3 Pro cameras

### DIFF
--- a/packages/eufy-security-scrypted/src/services/device/stream-service.ts
+++ b/packages/eufy-security-scrypted/src/services/device/stream-service.ts
@@ -175,15 +175,19 @@ export class StreamService {
     const { width, height } = this.getVideoDimensions(quality);
 
     // Simplified FFmpeg configuration for reliable Eufy camera streaming
+    // Note: Eufy battery cameras can have keyframe intervals of 9+ seconds,
+    // so we use extended analysis time to ensure we capture a keyframe.
     const ffmpegInput: FFmpegInput = {
       url: undefined,
       inputArguments: [
         "-use_wallclock_as_timestamps",
         "1", // Critical for Eufy streams - fixes timestamp issues
+        "-fflags",
+        "+genpts", // Generate presentation timestamps for proper sync
         "-analyzeduration",
-        "5000000", // Increased analysis time to find SPS/PPS headers
+        "15000000", // 15 seconds - extended for slow keyframe intervals
         "-probesize",
-        "5000000", // Increased probe size to find SPS/PPS headers
+        "15000000", // 15 MB - extended probe size for keyframe detection
         "-err_detect",
         "ignore_err", // Ignore non-fatal H.264 errors (SEI payload issues, etc.)
         "-f",

--- a/packages/eufy-security-scrypted/src/services/device/stream-service.ts
+++ b/packages/eufy-security-scrypted/src/services/device/stream-service.ts
@@ -184,6 +184,8 @@ export class StreamService {
         "5000000", // Increased analysis time to find SPS/PPS headers
         "-probesize",
         "5000000", // Increased probe size to find SPS/PPS headers
+        "-err_detect",
+        "ignore_err", // Ignore non-fatal H.264 errors (SEI payload issues, etc.)
         "-f",
         "h264", // Explicitly specify H.264 format
         "-i",

--- a/packages/eufy-stream-server/src/connection-manager.ts
+++ b/packages/eufy-stream-server/src/connection-manager.ts
@@ -94,10 +94,6 @@ export class ConnectionManager extends EventEmitter {
     };
     this.connectionInfo.set(connectionId, connectionInfo);
 
-    this.logger.info(
-      `Client connected: ${connectionId} from ${remoteAddress}:${remotePort}`
-    );
-
     // Set up socket event handlers
     socket.on("close", () => {
       this.handleDisconnection(connectionId);
@@ -140,7 +136,6 @@ export class ConnectionManager extends EventEmitter {
       this.connectionInfo.delete(connectionId);
     }
 
-    this.logger.info(`Client disconnected: ${connectionId}`);
     this.emit("clientDisconnected", connectionId);
   }
 

--- a/packages/eufy-stream-server/src/h264-parser.ts
+++ b/packages/eufy-stream-server/src/h264-parser.ts
@@ -232,15 +232,24 @@ export class H264Parser {
    */
   getNALTypeName(type: number): string {
     const names: Record<number, string> = {
-      1: "P-slice",
-      2: "B-slice",
-      3: "I-slice",
-      5: "IDR-slice",
+      0: "Unspecified",
+      1: "Non-IDR Slice",
+      2: "Data Partition A",
+      3: "Data Partition B",
+      4: "Data Partition C",
+      5: "IDR Slice",
       6: "SEI",
       7: "SPS",
       8: "PPS",
       9: "AUD",
-      14: "Data Partitioning",
+      10: "End of Sequence",
+      11: "End of Stream",
+      12: "Filler Data",
+      13: "SPS Extension",
+      14: "Prefix NAL",
+      15: "Subset SPS",
+      19: "Auxiliary Slice",
+      20: "Slice Extension",
     };
     return names[type] || `Unknown(${type})`;
   }

--- a/packages/eufy-stream-server/src/stream-server.ts
+++ b/packages/eufy-stream-server/src/stream-server.ts
@@ -90,6 +90,10 @@ export class StreamServer extends EventEmitter {
   private activityCheckInterval?: ReturnType<typeof setInterval>;
   private readonly ACTIVITY_TIMEOUT = 30000; // 30 seconds of no activity
 
+  // Keyframe interval tracking for diagnostics
+  private lastKeyframeTime = 0;
+  private readonly KEYFRAME_INTERVAL_WARNING_MS = 5000; // Warn if >5 seconds between keyframes
+
   // Statistics
   private stats = {
     framesProcessed: 0,
@@ -571,6 +575,20 @@ export class StreamServer extends EventEmitter {
         isKeyFrame = this.h264Parser.isKeyFrame(data);
       }
 
+      // Track keyframe intervals for diagnosing "Unable to find sync frame" issues
+      if (isKeyFrame) {
+        const now = Date.now();
+        if (this.lastKeyframeTime > 0) {
+          const keyframeInterval = now - this.lastKeyframeTime;
+          if (keyframeInterval > this.KEYFRAME_INTERVAL_WARNING_MS) {
+            this.logger.warn(
+              `⚠️ Long keyframe interval: ${Math.round(keyframeInterval / 1000)}s - may cause prebuffer sync issues`
+            );
+          }
+        }
+        this.lastKeyframeTime = now;
+      }
+
       // Log NAL unit information for debugging
       const nalUnits = this.h264Parser.extractNALUnits(data);
       const nalInfo = nalUnits
@@ -584,15 +602,23 @@ export class StreamServer extends EventEmitter {
 
       // Cache SPS/PPS NAL units for new client initialization
       // Type 7 = SPS (Sequence Parameter Set), Type 8 = PPS (Picture Parameter Set)
+      // IMPORTANT: Cache only the individual NAL unit with start code, not the entire buffer.
+      // Caching the entire buffer could include extra NAL units that cause "missing picture
+      // in access unit" errors when sent to FFmpeg as initialization data.
+      const startCode = Buffer.from([0x00, 0x00, 0x00, 0x01]);
       nalUnits.forEach((nal) => {
         if (nal.type === 7) {
-          // SPS
-          this.cachedSPS = data; // Cache the entire buffer containing SPS
-          this.logger.debug(`Cached SPS header (${data.length} bytes)`);
+          // SPS - cache only this NAL unit with start code prefix
+          this.cachedSPS = Buffer.concat([startCode, nal.data]);
+          this.logger.debug(
+            `Cached SPS NAL unit (${this.cachedSPS.length} bytes)`
+          );
         } else if (nal.type === 8) {
-          // PPS
-          this.cachedPPS = data; // Cache the entire buffer containing PPS
-          this.logger.debug(`Cached PPS header (${data.length} bytes)`);
+          // PPS - cache only this NAL unit with start code prefix
+          this.cachedPPS = Buffer.concat([startCode, nal.data]);
+          this.logger.debug(
+            `Cached PPS NAL unit (${this.cachedPPS.length} bytes)`
+          );
         }
       });
 

--- a/packages/eufy-stream-server/src/stream-server.ts
+++ b/packages/eufy-stream-server/src/stream-server.ts
@@ -113,6 +113,10 @@ export class StreamServer extends EventEmitter {
   private cachedSPS: Buffer | null = null;
   private cachedPPS: Buffer | null = null;
 
+  // Cached keyframe (IDR) for immediate playback when clients connect
+  // This allows new clients to start decoding immediately without waiting for next keyframe
+  private cachedKeyframe: Buffer | null = null;
+
   constructor(options: StreamServerOptions) {
     super();
 
@@ -187,18 +191,19 @@ export class StreamServer extends EventEmitter {
   }
 
   /**
-   * Send cached SPS/PPS headers to a specific client
-   * This ensures new clients can immediately decode the stream
+   * Send cached SPS/PPS headers and keyframe to a specific client
+   * This ensures new clients can immediately decode the stream without waiting for next keyframe
    * @param connectionId - The connection ID to send headers to
    */
   private sendCachedHeaders(connectionId: string): void {
-    if (!this.cachedSPS && !this.cachedPPS) {
+    if (!this.cachedSPS && !this.cachedPPS && !this.cachedKeyframe) {
       this.logger.debug(
-        `No cached SPS/PPS headers available for client ${connectionId}`
+        `No cached headers/keyframe available for client ${connectionId}`
       );
       return;
     }
 
+    // Send SPS first (required for decoder initialization)
     if (this.cachedSPS) {
       this.logger.debug(
         `Sending cached SPS header (${this.cachedSPS.length} bytes) to ${connectionId}`
@@ -206,11 +211,20 @@ export class StreamServer extends EventEmitter {
       this.connectionManager.sendToClient(connectionId, this.cachedSPS);
     }
 
+    // Send PPS second (required for decoder initialization)
     if (this.cachedPPS) {
       this.logger.debug(
         `Sending cached PPS header (${this.cachedPPS.length} bytes) to ${connectionId}`
       );
       this.connectionManager.sendToClient(connectionId, this.cachedPPS);
+    }
+
+    // Send cached keyframe last (allows immediate decoding)
+    if (this.cachedKeyframe) {
+      this.logger.info(
+        `📦 Sending cached keyframe (${this.cachedKeyframe.length} bytes) to ${connectionId} for immediate playback`
+      );
+      this.connectionManager.sendToClient(connectionId, this.cachedKeyframe);
     }
   }
 
@@ -621,6 +635,19 @@ export class StreamServer extends EventEmitter {
           );
         }
       });
+
+      // Cache keyframe (IDR slice) for immediate playback when new clients connect
+      // This prevents "Unable to find sync frame" errors in prebuffer
+      if (isKeyFrame) {
+        // Extract only the IDR NAL unit (type 5) for caching
+        const idrNal = nalUnits.find((nal) => nal.type === 5);
+        if (idrNal) {
+          this.cachedKeyframe = Buffer.concat([startCode, idrNal.data]);
+          this.logger.debug(
+            `Cached IDR keyframe (${this.cachedKeyframe.length} bytes)`
+          );
+        }
+      }
 
       // Resolve any pending snapshot requests with keyframe data
       // This happens BEFORE checking if server is active, so snapshots work without TCP server

--- a/packages/eufy-stream-server/tests/h264-parser.test.ts
+++ b/packages/eufy-stream-server/tests/h264-parser.test.ts
@@ -90,15 +90,28 @@ describe("H264Parser", () => {
 
   describe("getNALTypeName", () => {
     it("should return correct NAL type names", () => {
-      expect(parser.getNALTypeName(1)).toBe("P-slice");
-      expect(parser.getNALTypeName(5)).toBe("IDR-slice");
+      expect(parser.getNALTypeName(0)).toBe("Unspecified");
+      expect(parser.getNALTypeName(1)).toBe("Non-IDR Slice");
+      expect(parser.getNALTypeName(5)).toBe("IDR Slice");
+      expect(parser.getNALTypeName(6)).toBe("SEI");
       expect(parser.getNALTypeName(7)).toBe("SPS");
       expect(parser.getNALTypeName(8)).toBe("PPS");
+      expect(parser.getNALTypeName(9)).toBe("AUD");
       expect(parser.getNALTypeName(99)).toBe("Unknown(99)");
     });
 
-    it("should return 'Data Partitioning' for NAL type 14", () => {
-      expect(parser.getNALTypeName(14)).toBe("Data Partitioning");
+    it("should return correct names for data partition NAL types", () => {
+      // Data partitioning splits frame data across multiple NAL units
+      // These are rarely used but cause issues with FFmpeg (not implemented)
+      expect(parser.getNALTypeName(2)).toBe("Data Partition A");
+      expect(parser.getNALTypeName(3)).toBe("Data Partition B");
+      expect(parser.getNALTypeName(4)).toBe("Data Partition C");
+    });
+
+    it("should return correct names for extension NAL types", () => {
+      expect(parser.getNALTypeName(14)).toBe("Prefix NAL");
+      expect(parser.getNALTypeName(15)).toBe("Subset SPS");
+      expect(parser.getNALTypeName(20)).toBe("Slice Extension");
     });
   });
 });


### PR DESCRIPTION
I have a Homebase 3 and a few S3 Pro cameras which have not been working particularly well with the native Eufy <> Homekit bridge. With this Scrypted plugin, I'm able to take snapshots from these cameras but streams didn't seem to work until I fixed the NAL type names & bumped the analysis time.

I'm happy to adjust the branch if this is desirable on the mainline, but I'm mainly putting this out there to help others with these battery-powered cameras.