### PR TITLE
feat: update eufy-security-ws integration to v2.1.0

### DIFF
--- a/packages/eufy-security-client/src/station/commands.ts
+++ b/packages/eufy-security-client/src/station/commands.ts
@@ -113,6 +113,20 @@ export interface StationDownloadImageCommand
 }
 
 /**
+ * Query database records by date range from station
+ * Results are delivered as a station event (database query by date)
+ */
+export interface StationDatabaseQueryByDateCommand
+  extends BaseStationCommand<typeof STATION_COMMANDS.DATABASE_QUERY_BY_DATE> {
+  serialNumbers: string[];
+  startDate: string;
+  endDate: string;
+  eventType?: number;
+  detectionType?: number;
+  storageType?: number;
+}
+
+/**
  * Union type for all station commands
  */
 export type StationCommand =
@@ -129,4 +143,5 @@ export type StationCommand =
   | StationTriggerAlarmCommand
   | StationResetAlarmCommand
   | StationChimeCommand
-  | StationDownloadImageCommand;
+  | StationDownloadImageCommand
+  | StationDatabaseQueryByDateCommand;

--- a/packages/eufy-security-client/src/station/constants.ts
+++ b/packages/eufy-security-client/src/station/constants.ts
@@ -21,6 +21,7 @@ export const STATION_COMMANDS = {
   DOWNLOAD_IMAGE: "station.download_image",
   DATABASE_QUERY_LATEST_INFO: "station.database_query_latest_info",
   DATABASE_QUERY_LOCAL: "station.database_query_local",
+  DATABASE_QUERY_BY_DATE: "station.database_query_by_date",
   DATABASE_COUNT_BY_DATE: "station.database_count_by_date",
   DATABASE_DELETE: "station.database_delete",
 } as const;
@@ -36,6 +37,7 @@ export const STATION_EVENTS = {
   STATION_REMOVED: "station removed",
   CONNECTED: "connected",
   DISCONNECTED: "disconnected",
+  CONNECTION_ERROR: "connection error",
   PROPERTY_CHANGED: "property changed",
   ALARM_EVENT: "alarm event",
   ALARM_DELAY_EVENT: "alarm delay event",
@@ -46,6 +48,7 @@ export const STATION_EVENTS = {
   IMAGE_DOWNLOADED: "image downloaded",
   DATABASE_QUERY_LATEST: "database query latest",
   DATABASE_QUERY_LOCAL: "database query local",
+  DATABASE_QUERY_BY_DATE: "database query by date",
   DATABASE_COUNT_BY_DATE: "database count by date",
   DATABASE_DELETE: "database delete",
   COMMAND_RESULT: "command result",

--- a/packages/eufy-security-client/src/station/events.ts
+++ b/packages/eufy-security-client/src/station/events.ts
@@ -52,6 +52,13 @@ export interface StationDisconnectedEventPayload
   // No additional properties
 }
 
+export interface StationConnectionErrorEventPayload
+  extends BaseStationEventPayloadWithSerial<
+    typeof STATION_EVENTS.CONNECTION_ERROR
+  > {
+  // No additional properties
+}
+
 // Station property changed event payload
 export interface StationPropertyChangedEventPayload
   extends BaseStationEventPayloadWithSerial<
@@ -126,6 +133,14 @@ export interface StationDatabaseQueryLocalEventPayload
   data: JSONValue[];
 }
 
+export interface StationDatabaseQueryByDateEventPayload
+  extends BaseStationEventPayloadWithSerial<
+    typeof STATION_EVENTS.DATABASE_QUERY_BY_DATE
+  > {
+  returnCode: number;
+  data: JSONValue[];
+}
+
 export interface StationDatabaseCountByDateEventPayload
   extends BaseStationEventPayloadWithSerial<
     typeof STATION_EVENTS.DATABASE_COUNT_BY_DATE
@@ -158,6 +173,7 @@ export type StationEventPayload =
   | StationRemovedEventPayload
   | StationConnectedEventPayload
   | StationDisconnectedEventPayload
+  | StationConnectionErrorEventPayload
   | StationPropertyChangedEventPayload
   | StationAlarmEventPayload
   | StationAlarmDelayEventPayload
@@ -168,6 +184,7 @@ export type StationEventPayload =
   | StationImageDownloadedEventPayload
   | StationDatabaseQueryLatestEventPayload
   | StationDatabaseQueryLocalEventPayload
+  | StationDatabaseQueryByDateEventPayload
   | StationDatabaseCountByDateEventPayload
   | StationDatabaseDeleteEventPayload
   | StationCommandResultEventPayload;

--- a/packages/eufy-security-client/src/station/responses.ts
+++ b/packages/eufy-security-client/src/station/responses.ts
@@ -87,6 +87,13 @@ export type StationDatabaseQueryLocalResponse = {
 };
 
 /**
+ * Response from station.database_query_by_date
+ * Results are asynchronously delivered via the "database query by date" station event.
+ * The immediate response acknowledges the command was received.
+ */
+export type StationDatabaseQueryByDateResponse = {};
+
+/**
  * Response from station.database_count_by_date
  * Can be either success with count and date or error
  */
@@ -118,6 +125,7 @@ export interface StationCommandResponseMap {
   [STATION_COMMANDS.DOWNLOAD_IMAGE]: {};
   [STATION_COMMANDS.DATABASE_QUERY_LATEST_INFO]: StationDatabaseQueryLatestInfoResponse;
   [STATION_COMMANDS.DATABASE_QUERY_LOCAL]: StationDatabaseQueryLocalResponse;
+  [STATION_COMMANDS.DATABASE_QUERY_BY_DATE]: StationDatabaseQueryByDateResponse;
   [STATION_COMMANDS.DATABASE_COUNT_BY_DATE]: StationDatabaseCountByDateResponse;
   [STATION_COMMANDS.DATABASE_DELETE]: {};
   [STATION_COMMANDS.SET_PROPERTY]: {};
@@ -137,4 +145,5 @@ export type StationResponse =
   | StationHasCommandResponse
   | StationDatabaseQueryLatestInfoResponse
   | StationDatabaseQueryLocalResponse
+  | StationDatabaseQueryByDateResponse
   | StationDatabaseCountByDateResponse;

--- a/packages/eufy-security-scrypted/src/eufy-provider.ts
+++ b/packages/eufy-security-scrypted/src/eufy-provider.ts
@@ -840,18 +840,31 @@ export class EufySecurityProvider
       return;
     }
 
-    deviceSerials.forEach((deviceSerial) =>
-      DeviceUtils.createDeviceManifest(this.wsClient, deviceSerial).then(
-        (manifest) =>
-          deviceManager.onDevicesChanged({
-            providerNativeId: manifest.providerNativeId,
-            devices: [manifest],
-          })
+    // Resolve all manifests in parallel, then group by station (providerNativeId)
+    // and call onDevicesChanged once per station. This guarantees Scrypted assigns
+    // stable numeric IDs because it sees the full device list in a deterministic order.
+    const manifests = await Promise.all(
+      deviceSerials.map((serial) =>
+        DeviceUtils.createDeviceManifest(this.wsClient, serial)
       )
     );
 
+    const byStation = new Map<string | undefined, typeof manifests>();
+    for (const manifest of manifests) {
+      const key = manifest.providerNativeId;
+      if (!byStation.has(key)) byStation.set(key, []);
+      byStation.get(key)!.push(manifest);
+    }
+
+    for (const [providerNativeId, stationDevices] of byStation) {
+      await deviceManager.onDevicesChanged({
+        providerNativeId,
+        devices: stationDevices,
+      });
+    }
+
     this.logger.info(
-      `✅ Registered ${deviceSerials.length} devices from server state`
+      `✅ Registered ${deviceSerials.length} devices across ${byStation.size} station(s) from server state`
     );
   }
 

--- a/packages/eufy-security-scrypted/tests/unit/eufy-provider.test.ts
+++ b/packages/eufy-security-scrypted/tests/unit/eufy-provider.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for EufySecurityProvider
+ */
+
+import { EufySecurityProvider } from "../../src/eufy-provider";
+import { DeviceUtils } from "../../src/utils/device-utils";
+import sdk from "@scrypted/sdk";
+import { StartListeningResponse } from "@caplaz/eufy-security-client";
+
+jest.mock("@scrypted/sdk", () => ({
+  ScryptedDeviceBase: class {
+    storage = { getItem: jest.fn().mockReturnValue(null), setItem: jest.fn() };
+    console = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    nativeId = undefined;
+  },
+  ScryptedInterface: {
+    Camera: "Camera",
+    VideoCamera: "VideoCamera",
+    MotionSensor: "MotionSensor",
+    Settings: "Settings",
+    Refresh: "Refresh",
+    Battery: "Battery",
+    Charger: "Charger",
+    Sensors: "Sensors",
+    OnOff: "OnOff",
+    Brightness: "Brightness",
+    PanTiltZoom: "PanTiltZoom",
+    BinarySensor: "BinarySensor",
+    SecuritySystem: "SecuritySystem",
+  },
+  SecuritySystemMode: {
+    AwayArmed: "AwayArmed",
+    HomeArmed: "HomeArmed",
+    Disarmed: "Disarmed",
+    NightArmed: "NightArmed",
+  },
+  ChargeState: {
+    Charging: "Charging",
+    NotCharging: "NotCharging",
+  },
+  default: {
+    deviceManager: {
+      onDevicesChanged: jest.fn(),
+    },
+    mediaManager: {
+      createFFmpegMediaObject: jest.fn(),
+    },
+  },
+  deviceManager: {
+    onDevicesChanged: jest.fn(),
+  },
+}));
+
+jest.mock("../../src/utils/device-utils", () => ({
+  DeviceUtils: {
+    createDeviceManifest: jest.fn(),
+    createStationManifest: jest.fn(),
+    genericDeviceInformation: jest.fn().mockReturnValue([]),
+    allWriteableDeviceProperties: jest.fn().mockReturnValue([]),
+  },
+}));
+
+jest.mock("@caplaz/eufy-security-client", () => {
+  const actual = jest.requireActual("@caplaz/eufy-security-client");
+  return {
+    ...actual,
+    EufyWebSocketClient: jest.fn().mockImplementation(() => ({
+      isConnected: jest.fn().mockReturnValue(false),
+      on: jest.fn(),
+      off: jest.fn(),
+    })),
+    AuthenticationManager: jest.fn().mockImplementation(() => ({
+      on: jest.fn(),
+      off: jest.fn(),
+    })),
+  };
+});
+
+jest.mock("../../src/utils/memory-manager", () => ({
+  MemoryManager: {
+    setMemoryThreshold: jest.fn(),
+  },
+}));
+
+describe("EufySecurityProvider.registerDevicesFromServerState", () => {
+  let provider: EufySecurityProvider;
+  let mockOnDevicesChanged: jest.Mock;
+  let mockCreateDeviceManifest: jest.Mock;
+
+  beforeEach(() => {
+    mockOnDevicesChanged = (sdk.deviceManager.onDevicesChanged as jest.Mock);
+    mockOnDevicesChanged.mockClear();
+
+    mockCreateDeviceManifest = DeviceUtils.createDeviceManifest as jest.Mock;
+    mockCreateDeviceManifest.mockClear();
+
+    provider = new EufySecurityProvider("test-provider");
+  });
+
+  it("groups 3 devices across 2 stations into exactly 2 onDevicesChanged calls", async () => {
+    // Two devices on station A, one device on station B
+    const manifests = [
+      { nativeId: "device_CAM001", providerNativeId: "station_STA001", name: "Cam 1" },
+      { nativeId: "device_CAM002", providerNativeId: "station_STA001", name: "Cam 2" },
+      { nativeId: "device_CAM003", providerNativeId: "station_STA002", name: "Cam 3" },
+    ];
+
+    mockCreateDeviceManifest
+      .mockResolvedValueOnce(manifests[0])
+      .mockResolvedValueOnce(manifests[1])
+      .mockResolvedValueOnce(manifests[2]);
+
+    const serverState = {
+      state: {
+        devices: ["CAM001", "CAM002", "CAM003"],
+        stations: [],
+      },
+    } as unknown as StartListeningResponse;
+
+    await (provider as any).registerDevicesFromServerState(serverState);
+
+    expect(mockOnDevicesChanged).toHaveBeenCalledTimes(2);
+
+    const calls = mockOnDevicesChanged.mock.calls;
+    const callByStation = new Map(
+      calls.map((c: any[]) => [c[0].providerNativeId, c[0].devices])
+    );
+
+    expect(callByStation.get("station_STA001")).toHaveLength(2);
+    expect(callByStation.get("station_STA001")).toEqual(
+      expect.arrayContaining([manifests[0], manifests[1]])
+    );
+    expect(callByStation.get("station_STA002")).toHaveLength(1);
+    expect(callByStation.get("station_STA002")).toEqual([manifests[2]]);
+  });
+
+  it("makes a single onDevicesChanged call when all devices belong to one station", async () => {
+    const manifests = [
+      { nativeId: "device_CAM001", providerNativeId: "station_STA001", name: "Cam 1" },
+      { nativeId: "device_CAM002", providerNativeId: "station_STA001", name: "Cam 2" },
+    ];
+
+    mockCreateDeviceManifest
+      .mockResolvedValueOnce(manifests[0])
+      .mockResolvedValueOnce(manifests[1]);
+
+    const serverState = {
+      state: { devices: ["CAM001", "CAM002"], stations: [] },
+    } as unknown as StartListeningResponse;
+
+    await (provider as any).registerDevicesFromServerState(serverState);
+
+    expect(mockOnDevicesChanged).toHaveBeenCalledTimes(1);
+    expect(mockOnDevicesChanged).toHaveBeenCalledWith({
+      providerNativeId: "station_STA001",
+      devices: manifests,
+    });
+  });
+
+  it("does nothing when there are no devices", async () => {
+    const serverState = {
+      state: { devices: [], stations: [] },
+    } as unknown as StartListeningResponse;
+
+    await (provider as any).registerDevicesFromServerState(serverState);
+
+    expect(mockOnDevicesChanged).not.toHaveBeenCalled();
+    expect(mockCreateDeviceManifest).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- **Protocol compatibility:** Add missing station protocol types introduced in eufy-security-ws 1.9.9–2.1.0 (`station.database_query_by_date` command/event, `station.connection_error` event) so the client library is fully aligned with server schema v21.
- **Device ID stability:** Fix device ID instability (issues #18, #12) by batching `onDevicesChanged` calls once per station rather than once per device — matching the pattern already used by `registerStationsFromServerState`. Prevents Scrypted from reassigning numeric IDs on restart or when new devices are added.

## Changes

### `packages/eufy-security-client`
- `station/commands.ts` — `STATION_COMMANDS.DATABASE_QUERY_BY_DATE` + `StationDatabaseQueryByDateCommand` interface
- `station/constants.ts` — `STATION_EVENTS.DATABASE_QUERY_BY_DATE`, `STATION_EVENTS.CONNECTION_ERROR`
- `station/events.ts` — `StationDatabaseQueryByDateEventPayload`, `StationConnectionErrorEventPayload`
- `station/responses.ts` — `StationDatabaseQueryByDateResponse` in command-response map
- `CLIENT_MIN_SCHEMA` (13) and `CLIENT_PREFERRED_SCHEMA` (21) already aligned; 1.9.9→2.1.0 diff is formatting-only

### `packages/eufy-security-scrypted`
- `src/eufy-provider.ts` — `registerDevicesFromServerState()` now groups device manifests by `providerNativeId` (station) and calls `onDevicesChanged` once per station (was once per device)
- `tests/unit/eufy-provider.test.ts` — smoke tests for the eager batched registration path

## How to test

1. Install eufy-security-ws v2.1.0 server
2. Build the plugin: `npm run build`
3. Run tests: `npm test` — all existing + new unit tests should pass
4. Load the plugin in Scrypted with at least two cameras on the same station; restart the plugin and confirm device IDs remain stable (NVR cameras do not disappear/relink)

## Related

Closes #18 (C31 doorbell causes all devices to disappear)  
Closes #12 (T81A0 no devices found)  
Addresses eufy-security-ws 2.1.0 schema upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)