### PR TITLE
fix: gate Intercom on server-side hasCommand instead of microphone/speaker props

### DIFF
--- a/packages/eufy-security-scrypted/src/utils/device-utils.ts
+++ b/packages/eufy-security-scrypted/src/utils/device-utils.ts
@@ -282,13 +282,15 @@ export class DeviceUtils {
       ScryptedInterface.Refresh,
     ];
 
-    // Talkback requires both a microphone (to receive) and speaker (to play)
-    // on the device. Without these the camera will reject startTalkback and
-    // Scrypted would surface a non-functional talk button.
-    if (
-      properties.microphone !== undefined &&
-      properties.speaker !== undefined
-    ) {
+    // Talkback support varies by device. Ask the server (which consults the
+    // upstream eufy-security-client DeviceCommands table) rather than inferring
+    // it from the presence of `microphone`/`speaker` properties — many models
+    // that support talkback (e.g. BATTERY_DOORBELL_2 / S220) don't expose those
+    // properties at all, which previously hid the talk button in HomeKit.
+    // The argument is the upstream CommandName enum value (camelCase), not the
+    // snake_case WS protocol command name.
+    const { exists: hasTalkback } = await api.hasCommand("deviceStartTalkback");
+    if (hasTalkback) {
       interfaces.push(ScryptedInterface.Intercom);
     }
 

--- a/packages/eufy-security-scrypted/tests/unit/device-utils.test.ts
+++ b/packages/eufy-security-scrypted/tests/unit/device-utils.test.ts
@@ -66,16 +66,17 @@ jest.mock("../../src/utils/scrypted-device-detection", () => ({
   getScryptedDeviceType: jest.fn().mockReturnValue("Camera"),
 }));
 
-const makeApi = (properties: any) => ({
+const makeApi = (properties: any, hasTalkback = false) => ({
   getProperties: jest.fn().mockResolvedValue({ properties }),
   getPropertiesMetadata: jest.fn().mockResolvedValue({ properties: {} }),
+  hasCommand: jest.fn().mockResolvedValue({ exists: hasTalkback }),
 });
 
 const baseProps = { type: 1, name: "Test Cam", serialNumber: "CAM001" };
 
-const makeWsClient = (properties: any) => ({
+const makeWsClient = (properties: any, hasTalkback = false) => ({
   commands: {
-    device: jest.fn().mockReturnValue(makeApi(properties)),
+    device: jest.fn().mockReturnValue(makeApi(properties, hasTalkback)),
   },
 });
 
@@ -102,33 +103,28 @@ describe("DeviceUtils", () => {
       expect(result.interfaces).toContain("Refresh");
     });
 
-    it("adds Intercom when microphone AND speaker are present", async () => {
-      const wsClient = makeWsClient({
-        ...baseProps,
-        microphone: true,
-        speaker: true,
-      }) as any;
+    it("adds Intercom when the device supports deviceStartTalkback", async () => {
+      const wsClient = makeWsClient(baseProps, true) as any;
       const result = await DeviceUtils.createDeviceManifest(wsClient, "CAM001");
 
       expect(result.interfaces).toContain("Intercom");
     });
 
-    it("does NOT add Intercom when microphone is missing", async () => {
-      const wsClient = makeWsClient({ ...baseProps, speaker: true }) as any;
+    it("adds Intercom even when microphone/speaker properties are absent (e.g. S220)", async () => {
+      // BATTERY_DOORBELL_2 (S220) supports talkback but does not expose
+      // microphone/speaker boolean properties; the server's hasCommand check
+      // is authoritative.
+      const wsClient = makeWsClient(baseProps, true) as any;
       const result = await DeviceUtils.createDeviceManifest(wsClient, "CAM001");
 
-      expect(result.interfaces).not.toContain("Intercom");
+      expect(result.interfaces).toContain("Intercom");
     });
 
-    it("does NOT add Intercom when speaker is missing", async () => {
-      const wsClient = makeWsClient({ ...baseProps, microphone: true }) as any;
-      const result = await DeviceUtils.createDeviceManifest(wsClient, "CAM001");
-
-      expect(result.interfaces).not.toContain("Intercom");
-    });
-
-    it("does NOT add Intercom when neither microphone nor speaker is present", async () => {
-      const wsClient = makeWsClient(baseProps) as any;
+    it("does NOT add Intercom when the device does not support startTalkback", async () => {
+      const wsClient = makeWsClient(
+        { ...baseProps, microphone: true, speaker: true },
+        false,
+      ) as any;
       const result = await DeviceUtils.createDeviceManifest(wsClient, "CAM001");
 
       expect(result.interfaces).not.toContain("Intercom");


### PR DESCRIPTION
## Summary

Some doorbells that support two-way talk — notably **Video Doorbell S220 (BATTERY_DOORBELL_2)** — do not expose `microphone` or `speaker` boolean properties on the underlying eufy-security device. The current gate in `createDeviceManifest` (`device-utils.ts:288-293`) requires both properties to be present, so for these models the `Intercom` interface is never added and HomeKit / Scrypted hide the talk button.

Replace the property-presence check with a server-side `api.hasCommand("deviceStartTalkback")` call, which consults the authoritative `DeviceCommands` table in `eufy-security-client`. This is the same source of truth the server uses when actually executing talkback, so the manifest now matches what the device will accept at runtime.

## Repro

- Device: Eufy Video Doorbell S220 (T8210, BATTERY_DOORBELL_2)
- Connected via eufy-security-ws to caplaz/eufy-security-scrypted, exported to HomeKit
- Live video works, motion + doorbell press fire correctly
- Talk button absent in HomeKit; `device.interfaces` in the Scrypted REPL does not include `Intercom`

`getProperties` for the S220 returns a payload that does not include `microphone` or `speaker` (confirmed against the upstream property table for `BATTERY_DOORBELL_2`), so the `properties.microphone !== undefined && properties.speaker !== undefined` gate evaluates false and Intercom is skipped — even though the upstream `DeviceCommands` table for this model does include `CommandName.DeviceStartTalkback`.

## Fix

```ts
// The argument is the upstream CommandName enum value (camelCase), not the
// snake_case WS protocol command name.
const { exists: hasTalkback } = await api.hasCommand("deviceStartTalkback");
if (hasTalkback) {
  interfaces.push(ScryptedInterface.Intercom);
}
```

Note on the string: `api.hasCommand` proxies to `Device.hasCommand` upstream, which checks the value against the `CommandName` enum — those values are camelCase (`"deviceStartTalkback"`), not the snake-case WS protocol command name (`"device.start_talkback"` from `DEVICE_COMMANDS.START_TALKBACK`). It would be nice to export the `CommandName` enum from `@caplaz/eufy-security-client` so callers don't have to hard-code the string, but that's out of scope for this fix.

## Tests

Updated `tests/unit/device-utils.test.ts`:
- ✅ Intercom added when device supports `deviceStartTalkback`
- ✅ Intercom added when talkback is supported but `microphone`/`speaker` properties are absent (the S220 case)
- ✅ Intercom NOT added when device does not support `deviceStartTalkback`, even if `microphone` + `speaker` properties are present

All 11 tests in `device-utils.test.ts` pass.

## Test plan

- [x] `npm test -- device-utils.test.ts` passes locally
- [x] Lint + format pass (pre-commit hook)
- [x] Verified on hardware: `device.interfaces` now includes `Intercom` for an S220, and the HomeKit talk button works