### PR TITLE
fix: HEVC muxing — videoCodec=H265 + audio-aware mode (closes #23)

### DIFF
--- a/packages/eufy-security-scrypted/src/services/device/snapshot-service.ts
+++ b/packages/eufy-security-scrypted/src/services/device/snapshot-service.ts
@@ -58,13 +58,13 @@ export class SnapshotService {
       // It starts the camera stream, waits for a keyframe, captures it, then stops the stream
       const h264Keyframe = await this.streamServer.captureSnapshot(timeout);
 
-      this.logger.info(
-        `Captured H.264 keyframe: ${h264Keyframe.length} bytes - converting to JPEG`,
-      );
-
       // Detect codec from last received stream metadata (H264 or H265)
       const videoCodec =
         this.streamServer.getVideoMetadata()?.videoCodec ?? "H264";
+
+      this.logger.info(
+        `Captured ${videoCodec} keyframe: ${h264Keyframe.length} bytes - converting to JPEG`,
+      );
 
       // Convert keyframe to JPEG using FFmpeg
       const jpegBuffer = await FFmpegUtils.convertH264ToJPEG(

--- a/packages/eufy-security-scrypted/tests/unit/services/snapshot-service.test.ts
+++ b/packages/eufy-security-scrypted/tests/unit/services/snapshot-service.test.ts
@@ -102,8 +102,10 @@ describe("SnapshotService", () => {
     it("should log snapshot size", async () => {
       await service.takePicture();
 
+      // Codec label reflects whatever getVideoMetadata returns; the mock
+      // returns null, so the service defaults to "H264".
       expect(mockLogger.info).toHaveBeenCalledWith(
-        `Captured H.264 keyframe: ${mockH264Data.length} bytes - converting to JPEG`,
+        `Captured H264 keyframe: ${mockH264Data.length} bytes - converting to JPEG`,
       );
       expect(mockLogger.info).toHaveBeenCalledWith(
         `✅ Snapshot converted to JPEG: ${mockJpegData.length} bytes`,

--- a/packages/eufy-stream-server/src/jmuxer.d.ts
+++ b/packages/eufy-stream-server/src/jmuxer.d.ts
@@ -7,6 +7,13 @@ declare module "jmuxer" {
 
   export interface JMuxerOptions {
     mode?: "both" | "video" | "audio";
+    /**
+     * Either "H264" or "H265". Defaults to "H264" in JMuxer itself; must
+     * be set to "H265" when feeding HEVC bitstreams or the muxer writes an
+     * AVCC sample description over HEVC NAL units and the output fMP4 is
+     * undecodable.
+     */
+    videoCodec?: "H264" | "H265";
     fps?: number;
     flushingTime?: number;
     clearBuffer?: boolean;

--- a/packages/eufy-stream-server/src/stream-server.ts
+++ b/packages/eufy-stream-server/src/stream-server.ts
@@ -78,11 +78,20 @@ export class StreamServer extends EventEmitter {
    * Map of muxed-client socket → its dedicated JMuxer instance. Each
    * connection gets its own muxer so every consumer receives a complete
    * fMP4 init segment at the start of its stream.
+   *
+   * JMuxer must be constructed with the correct `videoCodec` (H.264 vs
+   * H.265) because the codec choice affects which remuxer / fMP4 sample
+   * description box it writes (`avcC` vs `hvcC`). The codec isn't known
+   * until the first video event arrives, so a muxed client connecting
+   * before the first frame is held in `pendingMuxerSockets` instead —
+   * counts as an active consumer (so the upstream livestream starts) but
+   * has no JMuxer yet.
    */
   private muxerStreams = new Map<
     net.Socket,
     { muxer: JMuxer; duplex: Duplex }
   >();
+  private pendingMuxerSockets = new Set<net.Socket>();
   private connectionManager: ConnectionManager;
   private h264Parser: H264Parser;
   private isActive = false;
@@ -241,13 +250,15 @@ export class StreamServer extends EventEmitter {
       this.cleanupStaleConnections();
 
       // Total consumer count = TCP video clients (snapshot, raw video) +
-      // in-process muxer clients (fMP4 over the muxed port). Without
+      // in-process muxer clients (fMP4 over the muxed port) + pending
+      // muxer clients still awaiting first-frame metadata. Without
       // counting the muxers here the activity timer was killing the
       // livestream whenever the muxer was the only consumer, which broke
       // long-lived downstream rebroadcast sessions.
       const totalConsumers =
         this.connectionManager.getActiveConnectionCount() +
-        this.muxerStreams.size;
+        this.muxerStreams.size +
+        this.pendingMuxerSockets.size;
 
       if (timeSinceActivity > this.ACTIVITY_TIMEOUT && totalConsumers === 0) {
         this.logger.info(
@@ -638,7 +649,44 @@ export class StreamServer extends EventEmitter {
    * meaningfully faster than the previous ffmpeg-subprocess approach and
    * matches what the Eufy cameras actually deliver byte-for-byte.
    */
-  private handleMuxedClient(socket: net.Socket): void {
+  private async handleMuxedClient(socket: net.Socket): Promise<void> {
+    // Mark this socket as a pending consumer immediately so the upstream
+    // livestream starts even though we don't yet have a JMuxer to feed.
+    // `updateLivestreamStateForMuxerClients` counts both pending and active
+    // muxers as consumers.
+    this.pendingMuxerSockets.add(socket);
+
+    const pendingCleanup = () => {
+      this.pendingMuxerSockets.delete(socket);
+    };
+    socket.on("close", pendingCleanup);
+    socket.on("error", pendingCleanup);
+
+    // Kick off the upstream livestream (no-op if already running).
+    this.updateLivestreamStateForMuxerClients();
+
+    // Wait for the codec to be known via the first video event's metadata.
+    // Defaults to H.264 if the camera/stream never delivers metadata in
+    // time — matches the previous (silently-wrong-for-H.265) behaviour
+    // rather than dropping the client.
+    let videoCodec: "H264" | "H265" = "H264";
+    try {
+      const metadata = await this.waitForVideoMetadata(15000);
+      const c = metadata.videoCodec.toUpperCase();
+      videoCodec = c === "H265" || c === "HEVC" ? "H265" : "H264";
+    } catch (e) {
+      this.logger.warn(
+        `Muxer client: timed out waiting for video metadata, defaulting to H264. ${e}`,
+      );
+    }
+
+    // Socket may have given up while we waited.
+    if (socket.destroyed || !this.pendingMuxerSockets.has(socket)) {
+      this.pendingMuxerSockets.delete(socket);
+      return;
+    }
+    this.pendingMuxerSockets.delete(socket);
+
     const videoFps = this.videoMetadata?.videoFPS ?? 15;
     // Always declare both tracks. The muxed client connects BEFORE the
     // first audio frame arrives from Eufy, so `audioMetadata` is null at
@@ -650,6 +698,7 @@ export class StreamServer extends EventEmitter {
 
     const muxer = new JMuxer({
       mode,
+      videoCodec,
       fps: videoFps,
       flushingTime: 0,
       clearBuffer: false,
@@ -661,7 +710,7 @@ export class StreamServer extends EventEmitter {
     duplex.on("data", (chunk: Buffer) => {
       if (!firstChunkLogged) {
         this.logger.info(
-          `JMuxer emitting fMP4 (first chunk: ${chunk.length} bytes, mode=${mode}, fps=${videoFps})`,
+          `JMuxer emitting fMP4 (first chunk: ${chunk.length} bytes, mode=${mode}, codec=${videoCodec}, fps=${videoFps})`,
         );
         firstChunkLogged = true;
       }
@@ -673,11 +722,11 @@ export class StreamServer extends EventEmitter {
 
     this.muxerStreams.set(socket, { muxer, duplex });
     this.logger.info(
-      `Muxed client attached (total active muxers: ${this.muxerStreams.size})`,
+      `Muxed client attached (codec=${videoCodec}, total active muxers: ${this.muxerStreams.size})`,
     );
 
-    // This is the first consumer of the stream — bring up the livestream
-    // if the stream server's TCP video clients haven't already started it.
+    // Re-evaluate consumer state now that the socket moved from pending →
+    // active. No-op if the livestream is already running.
     this.updateLivestreamStateForMuxerClients();
 
     const cleanup = () => {
@@ -706,7 +755,8 @@ export class StreamServer extends EventEmitter {
   private async updateLivestreamStateForMuxerClients(): Promise<void> {
     const totalConsumers =
       this.connectionManager.getActiveConnectionCount() +
-      this.muxerStreams.size;
+      this.muxerStreams.size +
+      this.pendingMuxerSockets.size;
 
     if (totalConsumers > 0 && !this.livestreamIntendedState) {
       this.livestreamIntendedState = true;
@@ -787,6 +837,12 @@ export class StreamServer extends EventEmitter {
       if (!socket.destroyed) socket.destroy();
     }
     this.muxerStreams.clear();
+
+    // Also close any muxer clients still waiting for first-frame metadata
+    for (const socket of this.pendingMuxerSockets) {
+      if (!socket.destroyed) socket.destroy();
+    }
+    this.pendingMuxerSockets.clear();
 
     // Close muxed server
     if (this.muxedServer) {
@@ -888,10 +944,20 @@ export class StreamServer extends EventEmitter {
         }
       });
 
-      // Resolve any pending snapshot requests with keyframe data
-      // This happens BEFORE checking if server is active, so snapshots work without TCP server
+      // Resolve any pending snapshot requests with keyframe data.
+      // Snapshot requests need a decodable picture, so parameter-set-only
+      // events (H.264 SPS/PPS or H.265 VPS/SPS/PPS without an IRAP slice)
+      // don't qualify — FFmpeg can't produce a JPEG from those alone.
+      // H.264: require IDR (type 5).  H.265: require an IRAP slice
+      // (types 16–23: BLA/IDR/CRA and reserved IRAP).
+      //
+      // This happens BEFORE checking if server is active, so snapshots
+      // work without TCP server.
+      const hasSnapshotKeyframe = isHevc
+        ? nalUnits.some((nal) => nal.type >= 16 && nal.type <= 23)
+        : nalUnits.some((nal) => nal.type === 5);
       let snapshotsHandled = false;
-      if (isKeyFrame && this.snapshotResolvers.length > 0) {
+      if (hasSnapshotKeyframe && this.snapshotResolvers.length > 0) {
         this.logger.debug(
           `Resolving ${this.snapshotResolvers.length} snapshot request(s) with keyframe data`,
         );

--- a/packages/eufy-stream-server/src/stream-server.ts
+++ b/packages/eufy-stream-server/src/stream-server.ts
@@ -111,6 +111,17 @@ export class StreamServer extends EventEmitter {
   // Audio metadata from first audio frame
   private audioMetadata: AudioMetadata | null = null;
 
+  /**
+   * Whether this camera actually delivers an audio track. Many Eufy cameras
+   * run with the mic disabled (`microphone: false`) and send video only.
+   * JMuxer in `both` mode never emits fMP4 until EVERY declared track has a
+   * sample (see remux `isReady()`), so muxing a video-only camera as `both`
+   * hangs forever and the downstream ffmpeg times out. We detect audio
+   * empirically (set true the first time any audio frame arrives) and pick
+   * the muxer mode accordingly. `undefined` = not yet determined.
+   */
+  private deliversAudio: boolean | undefined = undefined;
+
   // Client activity monitoring for battery optimization
   private lastClientActivity = 0;
   private activityCheckInterval?: ReturnType<typeof setInterval>;
@@ -432,6 +443,10 @@ export class StreamServer extends EventEmitter {
           return;
         }
 
+        // This camera delivers audio — remember it so muxers use `both` mode.
+        // (Mic-off cameras never reach here, so `deliversAudio` stays false.)
+        this.deliversAudio = true;
+
         if (!this.audioMetadata && event.metadata) {
           this.audioMetadata = event.metadata;
           this.logger.info(
@@ -685,16 +700,40 @@ export class StreamServer extends EventEmitter {
       this.pendingMuxerSockets.delete(socket);
       return;
     }
-    this.pendingMuxerSockets.delete(socket);
 
     const videoFps = this.videoMetadata?.videoFPS ?? 15;
-    // Always declare both tracks. The muxed client connects BEFORE the
-    // first audio frame arrives from Eufy, so `audioMetadata` is null at
-    // this point on a cold start; if we picked mode based on it we'd lock
-    // in video-only and silently drop every audio frame thereafter.
-    // JMuxer's `both` mode correctly holds audio until the video track is
-    // ready, then emits both tracks into the fMP4 moov.
-    const mode = "both";
+
+    // Pick the muxer mode by whether this camera actually delivers audio.
+    // JMuxer `both` will not emit a single fMP4 byte until BOTH the video
+    // AND audio tracks have a sample (remux `isReady()`), so a mic-off,
+    // video-only camera muxed as `both` hangs forever and the downstream
+    // ffmpeg dies with "timeout waiting for data" — live view never starts.
+    //
+    // If we've already seen audio from this device, use `both`. If we know
+    // it's video-only, use `video`. If we don't know yet (first stream,
+    // muxer connects before the first audio frame), briefly wait for an
+    // audio frame now that video is confirmed flowing — a mic-on camera
+    // delivers audio within ~1-2s of video; if none arrives, it's video-only.
+    // The socket stays in `pendingMuxerSockets` during this wait so it still
+    // counts as a consumer (keeping the livestream alive).
+    if (this.deliversAudio === undefined) {
+      const audioDeadline = Date.now() + 2500;
+      while (Date.now() < audioDeadline && this.deliversAudio === undefined) {
+        if (socket.destroyed) {
+          this.pendingMuxerSockets.delete(socket);
+          return;
+        }
+        await new Promise((r) => setTimeout(r, 150));
+      }
+      if (this.deliversAudio === undefined) this.deliversAudio = false;
+    }
+
+    // Now graduate the socket from pending → active muxer.
+    this.pendingMuxerSockets.delete(socket);
+    const mode: "both" | "video" = this.deliversAudio ? "both" : "video";
+    this.logger.info(
+      `Muxer mode=${mode} (deliversAudio=${this.deliversAudio}) for ${this.options.serialNumber}`,
+    );
 
     const muxer = new JMuxer({
       mode,

--- a/packages/eufy-stream-server/tests/stream-server.test.ts
+++ b/packages/eufy-stream-server/tests/stream-server.test.ts
@@ -746,6 +746,30 @@ describe("StreamServer", () => {
       await expect(snapshotPromise).rejects.toThrow(/timed out/i);
     });
 
+    it("does NOT resolve snapshot on H.265 parameter sets without IRAP", async () => {
+      // Seed metadata via a parameter-set-only event (codec still gets
+      // detected from event.metadata).
+      const psOnly = Buffer.concat([
+        createTestHevcVpsData(),
+        createTestHevcSpsData(),
+        createTestHevcPpsData(),
+      ]);
+
+      // Begin snapshot capture
+      const snapshotPromise = serverWithWs.captureSnapshot(200);
+      await wait(50);
+
+      // Deliver only VPS+SPS+PPS — no IRAP/IDR slice. FFmpeg can't decode
+      // a JPEG from parameter sets alone, so the resolver must wait.
+      eventHandler({
+        serialNumber: "H265_DEVICE",
+        buffer: { data: psOnly },
+        metadata: h265Metadata,
+      });
+
+      await expect(snapshotPromise).rejects.toThrow(/timed out/i);
+    });
+
     it("caches H.265 VPS, SPS and PPS and sends them to new clients", async () => {
       const vpsData = createTestHevcVpsData();
       const spsData = createTestHevcSpsData();
@@ -823,10 +847,34 @@ describe("StreamServer", () => {
 
   describe("audio event handler", () => {
     let audioCallback: (event: any) => void;
+    let videoCallback: (event: any) => void;
+
+    // Seed video metadata so handleMuxedClient's waitForVideoMetadata
+    // resolves quickly. Without this it would block for 15s waiting for
+    // the first video frame, and tests that rely on a muxer being attached
+    // would time out.
+    const seedVideoMetadata = () => {
+      const startCode = Buffer.from([0x00, 0x00, 0x00, 0x01]);
+      // Minimal H.264 SPS NAL — content irrelevant for metadata capture.
+      const nal = Buffer.from([0x67, 0x42, 0x00, 0x1e]);
+      videoCallback({
+        serialNumber: "TEST_DEVICE_123",
+        buffer: { data: Buffer.concat([startCode, nal]) },
+        metadata: {
+          videoCodec: "H264",
+          videoFPS: 30,
+          videoWidth: 1280,
+          videoHeight: 720,
+        },
+      });
+    };
 
     beforeEach(async () => {
       await server.start();
-      // Audio listener is registered as the second addEventListener call
+      const videoCall = mockWsClient.addEventListener.mock.calls.find(
+        (call: any[]) => call[0] === "livestream video data",
+      );
+      videoCallback = videoCall[1];
       const audioCall = mockWsClient.addEventListener.mock.calls.find(
         (call: any[]) => call[0] === "livestream audio data",
       );
@@ -875,6 +923,9 @@ describe("StreamServer", () => {
         host: "127.0.0.1",
       });
       await new Promise((resolve) => socket.on("connect", resolve));
+      // Seed video metadata so handleMuxedClient's metadata-wait resolves
+      // and the JMuxer gets constructed.
+      seedVideoMetadata();
       await wait(50);
 
       expect((server as any).muxerStreams.size).toBe(1);
@@ -910,6 +961,7 @@ describe("StreamServer", () => {
         host: "127.0.0.1",
       });
       await new Promise((resolve) => socket.on("connect", resolve));
+      seedVideoMetadata();
       await wait(50);
 
       expect((server as any).muxerStreams.size).toBe(1);
@@ -936,6 +988,30 @@ describe("StreamServer", () => {
   });
 
   describe("handleMuxedClient", () => {
+    // JMuxer is only constructed after the first video event arrives (so
+    // the muxer can be created with the correct codec). Helper to seed
+    // that metadata and unblock the in-flight `waitForVideoMetadata`.
+    const seedVideoMetadata = (s: StreamServer, codec: string = "H264") => {
+      const videoCall = (
+        (s as any).options.wsClient as any
+      ).addEventListener.mock.calls.find(
+        (call: any[]) => call[0] === "livestream video data",
+      );
+      const videoCallback = videoCall[1];
+      const startCode = Buffer.from([0x00, 0x00, 0x00, 0x01]);
+      const nal = Buffer.from([0x67, 0x42, 0x00, 0x1e]);
+      videoCallback({
+        serialNumber: "TEST_DEVICE_123",
+        buffer: { data: Buffer.concat([startCode, nal]) },
+        metadata: {
+          videoCodec: codec,
+          videoFPS: 30,
+          videoWidth: 1280,
+          videoHeight: 720,
+        },
+      });
+    };
+
     it("adds muxer to map on connection", async () => {
       await server.start();
 
@@ -947,9 +1023,14 @@ describe("StreamServer", () => {
         host: "127.0.0.1",
       });
       await new Promise((resolve) => socket.on("connect", resolve));
+      // Connection alone only registers the socket as pending; the muxer
+      // is built after the first video event delivers metadata. Seed the
+      // metadata, then wait for handleMuxedClient to construct the muxer.
+      seedVideoMetadata(server);
       await wait(50);
 
       expect((server as any).muxerStreams.size).toBe(1);
+      expect((server as any).pendingMuxerSockets.size).toBe(0);
 
       socket.destroy();
     });
@@ -963,6 +1044,7 @@ describe("StreamServer", () => {
         host: "127.0.0.1",
       });
       await new Promise((resolve) => socket.on("connect", resolve));
+      seedVideoMetadata(server);
       await wait(50);
 
       expect((server as any).muxerStreams.size).toBe(1);
@@ -978,6 +1060,67 @@ describe("StreamServer", () => {
       expect(muxerInstance.destroy).toHaveBeenCalled();
     });
 
+    it("constructs JMuxer with videoCodec=H264 for H.264 streams", async () => {
+      await server.start();
+
+      const muxedPort = server.getMuxedPort()!;
+      const socket = net.createConnection({
+        port: muxedPort,
+        host: "127.0.0.1",
+      });
+      await new Promise((resolve) => socket.on("connect", resolve));
+      seedVideoMetadata(server, "H264");
+      await wait(50);
+
+      const JMuxerMock = require("jmuxer").default;
+      const lastCall =
+        JMuxerMock.mock.calls[JMuxerMock.mock.calls.length - 1][0];
+      expect(lastCall.videoCodec).toBe("H264");
+
+      socket.destroy();
+    });
+
+    it("constructs JMuxer with videoCodec=H265 for H.265 streams", async () => {
+      await server.start();
+
+      const muxedPort = server.getMuxedPort()!;
+      const socket = net.createConnection({
+        port: muxedPort,
+        host: "127.0.0.1",
+      });
+      await new Promise((resolve) => socket.on("connect", resolve));
+      seedVideoMetadata(server, "H265");
+      await wait(50);
+
+      const JMuxerMock = require("jmuxer").default;
+      const lastCall =
+        JMuxerMock.mock.calls[JMuxerMock.mock.calls.length - 1][0];
+      expect(lastCall.videoCodec).toBe("H265");
+
+      socket.destroy();
+    });
+
+    it("pending muxer client counts as a consumer (triggers livestream start)", async () => {
+      await server.start();
+
+      const muxedPort = server.getMuxedPort()!;
+      const socket = net.createConnection({
+        port: muxedPort,
+        host: "127.0.0.1",
+      });
+      await new Promise((resolve) => socket.on("connect", resolve));
+      // Don't seed metadata — leave the socket pending. The livestream
+      // state machine should still consider it a consumer and ask the WS
+      // client to start the livestream.
+      await wait(20);
+
+      expect(
+        mockWsClient.commands.device().startLivestream,
+      ).toHaveBeenCalled();
+
+      socket.destroy();
+    });
+
     it("JMuxer duplex data is written to socket", async () => {
       await server.start();
 
@@ -991,6 +1134,7 @@ describe("StreamServer", () => {
       socket.on("data", (chunk) => receivedChunks.push(chunk as Buffer));
 
       await new Promise((resolve) => socket.on("connect", resolve));
+      seedVideoMetadata(server);
       await wait(50);
 
       const JMuxerMock = require("jmuxer").default;

--- a/packages/eufy-stream-server/tests/stream-server.test.ts
+++ b/packages/eufy-stream-server/tests/stream-server.test.ts
@@ -854,6 +854,10 @@ describe("StreamServer", () => {
     // the first video frame, and tests that rely on a muxer being attached
     // would time out.
     const seedVideoMetadata = () => {
+      // These tests exercise audio, so mark the device as audio-capable to
+      // skip the muxer's audio-detection wait and create it immediately
+      // (in "both" mode), matching the assumption these tests were written under.
+      (server as any).deliversAudio = true;
       const startCode = Buffer.from([0x00, 0x00, 0x00, 0x01]);
       // Minimal H.264 SPS NAL — content irrelevant for metadata capture.
       const nal = Buffer.from([0x67, 0x42, 0x00, 0x1e]);
@@ -992,6 +996,10 @@ describe("StreamServer", () => {
     // the muxer can be created with the correct codec). Helper to seed
     // that metadata and unblock the in-flight `waitForVideoMetadata`.
     const seedVideoMetadata = (s: StreamServer, codec: string = "H264") => {
+      // Default these tests to audio-capable so the muxer is built
+      // immediately (mode "both"), as they were written before audio-aware
+      // mode existed. The video-only path has its own dedicated tests.
+      (s as any).deliversAudio = true;
       const videoCall = (
         (s as any).options.wsClient as any
       ).addEventListener.mock.calls.find(
@@ -1097,6 +1105,62 @@ describe("StreamServer", () => {
         JMuxerMock.mock.calls[JMuxerMock.mock.calls.length - 1][0];
       expect(lastCall.videoCodec).toBe("H265");
 
+      socket.destroy();
+    });
+
+    it("muxes in 'both' mode when the device delivers audio", async () => {
+      await server.start();
+      const socket = net.createConnection({
+        port: server.getMuxedPort()!,
+        host: "127.0.0.1",
+      });
+      await new Promise((resolve) => socket.on("connect", resolve));
+      seedVideoMetadata(server, "H265"); // helper marks deliversAudio = true
+      await wait(50);
+
+      const JMuxerMock = require("jmuxer").default;
+      const lastCall =
+        JMuxerMock.mock.calls[JMuxerMock.mock.calls.length - 1][0];
+      expect(lastCall.mode).toBe("both");
+      socket.destroy();
+    });
+
+    it("muxes in 'video' mode for a video-only (mic-off) camera", async () => {
+      await server.start();
+      const socket = net.createConnection({
+        port: server.getMuxedPort()!,
+        host: "127.0.0.1",
+      });
+      await new Promise((resolve) => socket.on("connect", resolve));
+
+      // Known video-only: skip the audio-detection wait. (Without this the
+      // muxer would block ~2.5s waiting for an audio frame that never comes.)
+      (server as any).deliversAudio = false;
+
+      // Seed video metadata directly — the helper would force audio=true.
+      const videoCallback = (
+        (server as any).options.wsClient as any
+      ).addEventListener.mock.calls.find(
+        (call: any[]) => call[0] === "livestream video data",
+      )[1];
+      videoCallback({
+        serialNumber: "TEST_DEVICE_123",
+        buffer: {
+          data: Buffer.from([0x00, 0x00, 0x00, 0x01, 0x67, 0x42, 0x00, 0x1e]),
+        },
+        metadata: {
+          videoCodec: "H265",
+          videoFPS: 15,
+          videoWidth: 1920,
+          videoHeight: 1080,
+        },
+      });
+      await wait(50);
+
+      const JMuxerMock = require("jmuxer").default;
+      const lastCall =
+        JMuxerMock.mock.calls[JMuxerMock.mock.calls.length - 1][0];
+      expect(lastCall.mode).toBe("video");
       socket.destroy();
     });
 


### PR DESCRIPTION
## Closes #23

Two fixes that make the muxed fMP4 path work for H.265/HEVC cameras (T86P2 S330, T8170 S340, E30, …).

### 1. Pass `videoCodec: 'H265'` to JMuxer
Upstream builds JMuxer without a codec, so it defaults to H.264 and writes an `avc1` moov even for HEVC streams — ffmpeg then advertises H.264, can't find a sync frame, and every consumer times out (the symptom in #23 and the thread).

`jmuxer@2.1.0` *does* have a full HEVC path (`H265Remuxer`, `hvcC`/`hvc1` generation); it's just gated behind the `videoCodec` option. Setting it from the captured `videoMetadata.videoCodec` produces a proper `hvc1` mp4 — verified `ffprobe → codec_name=hevc`, rebroadcast SDP `H265/90000` with `sprop-vps/sps/pps`, audio preserved. No muxer swap needed.

### 2. Audio-aware muxer mode
JMuxer `mode: 'both'` never emits an fMP4 byte until *both* tracks have a sample (`remux isReady()`). Mic-off cameras (`microphone: false`) send video only, so `both` hangs forever — same `timeout waiting for data`, but only on cameras without a mic. We detect audio empirically and mux `video`-only when the camera delivers no audio track.

Verified end-to-end on real hardware: a captured mic-off H.265 stream muxes to valid, ffmpeg-decodable fMP4 (`both` → 0 bytes; `video` → clean stream). All `eufy-stream-server` tests pass.

This is the minimal subset for HEVC streaming; the broader reliability work (cold-start recovery, per-station stream coordination, thumbnail caching) is in a separate PR.
