### PR TITLE
fix: three streaming correctness bugs (rate limiter, param-set cache, stop gate)

### DIFF
--- a/packages/eufy-security-client/src/utils/websocket-message-processor.ts
+++ b/packages/eufy-security-client/src/utils/websocket-message-processor.ts
@@ -89,16 +89,27 @@ export class WebSocketMessageProcessor {
   }
 
   /**
+   * Messages that must NEVER be dropped by the rate limiter:
+   *  - livestream video/audio data — a streaming camera alone produces
+   *    ~15 video + ~40 ADTS audio events per second, so any global
+   *    per-second cap is exceeded the moment two cameras stream (or one
+   *    camera streams during an event burst). A dropped video event means
+   *    missing NAL units → corrupted/black video downstream.
+   *  - command results — dropping one strands its pending command promise
+   *    until the command timeout.
+   */
+  private isRateLimitExempt(messageStr: string): boolean {
+    return (
+      messageStr.includes(`"${DEVICE_EVENTS.LIVESTREAM_VIDEO_DATA}"`) ||
+      messageStr.includes(`"${DEVICE_EVENTS.LIVESTREAM_AUDIO_DATA}"`) ||
+      messageStr.includes(`"type":"${MESSAGE_TYPES.RESULT}"`)
+    );
+  }
+
+  /**
    * Process a raw WebSocket message with validation and rate limiting
    */
   processMessage(data: any): { valid: boolean; message?: any; error?: string } {
-    // Rate limiting check
-    if (!this.rateLimiter.canProcess()) {
-      this.rateLimitedMessages++;
-      this.logger?.warn("Message rate limit exceeded, dropping message");
-      return { valid: false, error: "Rate limit exceeded" };
-    }
-
     // Basic data validation
     if (!data) {
       this.invalidMessages++;
@@ -112,6 +123,16 @@ export class WebSocketMessageProcessor {
     } catch (_error) {
       this.invalidMessages++;
       return { valid: false, error: "Failed to convert message to string" };
+    }
+
+    // Rate limiting — stream data and command results are exempt and do not
+    // consume the budget; the cap only applies to everything else.
+    if (!this.isRateLimitExempt(messageStr)) {
+      if (!this.rateLimiter.canProcess()) {
+        this.rateLimitedMessages++;
+        this.logger?.warn("Message rate limit exceeded, dropping message");
+        return { valid: false, error: "Rate limit exceeded" };
+      }
     }
 
     // Smart message size filtering - allow important message types to be larger

--- a/packages/eufy-security-client/tests/unit/utils.test.ts
+++ b/packages/eufy-security-client/tests/unit/utils.test.ts
@@ -155,6 +155,86 @@ describe("Utils Module", () => {
         const stats = rateLimitedProcessor.getStats();
         expect(stats.rateLimitedMessages).toBe(1);
       });
+
+      it("never rate-limits livestream video/audio data messages", () => {
+        const processor = new WebSocketMessageProcessor(undefined, {
+          maxMessagesPerSecond: 3,
+          rateLimitWindowMs: 60_000,
+        });
+
+        const videoMsg = JSON.stringify({
+          type: MESSAGE_TYPES.EVENT,
+          event: {
+            source: "device",
+            event: DEVICE_EVENTS.LIVESTREAM_VIDEO_DATA,
+            serialNumber: "T8210TEST",
+            buffer: { data: [0, 0, 0, 1, 0x65, 1, 2, 3] },
+          },
+        });
+        const audioMsg = JSON.stringify({
+          type: MESSAGE_TYPES.EVENT,
+          event: {
+            source: "device",
+            event: DEVICE_EVENTS.LIVESTREAM_AUDIO_DATA,
+            serialNumber: "T8210TEST",
+            buffer: { data: [255, 241, 1, 2, 3] },
+          },
+        });
+
+        // A single camera easily exceeds any per-second budget (video +
+        // audio events). None of these may ever be dropped.
+        for (let i = 0; i < 20; i++) {
+          expect(processor.processMessage(videoMsg).valid).toBe(true);
+          expect(processor.processMessage(audioMsg).valid).toBe(true);
+        }
+        expect(processor.getStats().rateLimitedMessages).toBe(0);
+      });
+
+      it("never rate-limits command result messages", () => {
+        const processor = new WebSocketMessageProcessor(undefined, {
+          maxMessagesPerSecond: 2,
+          rateLimitWindowMs: 60_000,
+        });
+
+        const resultMsg = JSON.stringify({
+          type: MESSAGE_TYPES.RESULT,
+          messageId: "abc",
+          success: true,
+          result: {},
+        });
+
+        // Dropping a result message would strand its pending command promise.
+        for (let i = 0; i < 10; i++) {
+          expect(processor.processMessage(resultMsg).valid).toBe(true);
+        }
+        expect(processor.getStats().rateLimitedMessages).toBe(0);
+      });
+
+      it("exempt messages do not consume the budget of limited messages", () => {
+        const processor = new WebSocketMessageProcessor(undefined, {
+          maxMessagesPerSecond: 2,
+          rateLimitWindowMs: 60_000,
+        });
+
+        const videoMsg = JSON.stringify({
+          type: MESSAGE_TYPES.EVENT,
+          event: {
+            source: "device",
+            event: DEVICE_EVENTS.LIVESTREAM_VIDEO_DATA,
+            serialNumber: "T8210TEST",
+            buffer: { data: [1] },
+          },
+        });
+        for (let i = 0; i < 5; i++) {
+          expect(processor.processMessage(videoMsg).valid).toBe(true);
+        }
+
+        // The generic budget (2/window) must still be fully available.
+        const generic = JSON.stringify({ type: "test" });
+        expect(processor.processMessage(generic).valid).toBe(true);
+        expect(processor.processMessage(generic).valid).toBe(true);
+        expect(processor.processMessage(generic).valid).toBe(false);
+      });
     });
 
     describe("large message handling", () => {

--- a/packages/eufy-stream-server/src/stream-server.ts
+++ b/packages/eufy-stream-server/src/stream-server.ts
@@ -369,6 +369,11 @@ export class StreamServer extends EventEmitter {
   private cachedPPS: Buffer | null = null;
   private cachedVPS: Buffer | null = null; // H.265 Video Parameter Set
 
+  /** Annex-B 4-byte start code used to re-frame cached parameter-set NALs. */
+  private static readonly ANNEX_B_START_CODE = Buffer.from([
+    0x00, 0x00, 0x00, 0x01,
+  ]);
+
   // Last decodable keyframe, retained so snapshots/thumbnails can be served
   // without waking the camera. Populated whenever a keyframe flows through —
   // from live view, HKSV recording, a motion-triggered stream, or a prior
@@ -1476,21 +1481,25 @@ export class StreamServer extends EventEmitter {
       clearTimeout(this.startStopTimeout);
       this.startStopTimeout = undefined;
     }
+    this.cancelPostSnapshotLinger("server stopping");
 
     // Stop activity monitoring
     this.stopActivityMonitoring();
 
-    // Guarantee the registry sees this device as no longer streaming, even
-    // if the teardown below doesn't traverse the graceful-stop branch.
-    this.setLivestreamActual(false);
-    this.releaseStreamSlot();
-
-    // Stop livestream if there are active clients
-    const activeClients = this.connectionManager.getActiveConnectionCount();
-    if (activeClients > 0) {
+    // Stop the upstream livestream if we intended it to run. Gate on intent,
+    // not on raw TCP client count — the normal HomeKit path attaches only
+    // muxed-port consumers (zero raw TCP clients), and skipping the stop for
+    // them left the camera streaming after a plugin reload/shutdown until
+    // the upstream idled it out (battery drain on every restart).
+    if (this.livestreamIntendedState) {
       this.livestreamIntendedState = false;
       await this.ensureLivestreamState();
     }
+
+    // Guarantee the registry sees this device as no longer streaming, even
+    // if the teardown above didn't traverse the graceful-stop branch.
+    this.setLivestreamActual(false);
+    this.releaseStreamSlot();
 
     // Clean up WebSocket event listeners
     if (this.eventRemover) {
@@ -1603,22 +1612,41 @@ export class StreamServer extends EventEmitter {
 
       // Cache parameter-set NAL units so new clients can decode mid-stream.
       // H.264: SPS=7, PPS=8   H.265: VPS=32, SPS=33, PPS=34
+      //
+      // Cache the individual NAL (re-framed with a start code), NOT the whole
+      // event buffer. Eufy usually bundles the parameter sets with the IDR in
+      // one event; caching the full event would put a stale keyframe inside
+      // every cache slot — new clients would receive old frames ahead of the
+      // live stream, and the snapshot prepend path would place an old IDR
+      // before the fresh one (ffmpeg decodes the FIRST picture it finds).
       nalUnits.forEach((nal) => {
+        const framedNal = () =>
+          Buffer.concat([StreamServer.ANNEX_B_START_CODE, nal.data]);
         if (!isHevc && nal.type === 7) {
-          this.cachedSPS = data;
-          this.logger.debug(`Cached H.264 SPS (${data.length} bytes)`);
+          this.cachedSPS = framedNal();
+          this.logger.debug(
+            `Cached H.264 SPS (${this.cachedSPS.length} bytes)`,
+          );
         } else if (!isHevc && nal.type === 8) {
-          this.cachedPPS = data;
-          this.logger.debug(`Cached H.264 PPS (${data.length} bytes)`);
+          this.cachedPPS = framedNal();
+          this.logger.debug(
+            `Cached H.264 PPS (${this.cachedPPS.length} bytes)`,
+          );
         } else if (isHevc && nal.type === 32) {
-          this.cachedVPS = data;
-          this.logger.debug(`Cached H.265 VPS (${data.length} bytes)`);
+          this.cachedVPS = framedNal();
+          this.logger.debug(
+            `Cached H.265 VPS (${this.cachedVPS.length} bytes)`,
+          );
         } else if (isHevc && nal.type === 33) {
-          this.cachedSPS = data;
-          this.logger.debug(`Cached H.265 SPS (${data.length} bytes)`);
+          this.cachedSPS = framedNal();
+          this.logger.debug(
+            `Cached H.265 SPS (${this.cachedSPS.length} bytes)`,
+          );
         } else if (isHevc && nal.type === 34) {
-          this.cachedPPS = data;
-          this.logger.debug(`Cached H.265 PPS (${data.length} bytes)`);
+          this.cachedPPS = framedNal();
+          this.logger.debug(
+            `Cached H.265 PPS (${this.cachedPPS.length} bytes)`,
+          );
         }
       });
 

--- a/packages/eufy-stream-server/tests/stream-server.test.ts
+++ b/packages/eufy-stream-server/tests/stream-server.test.ts
@@ -1653,4 +1653,116 @@ describe("StreamServer", () => {
       socket.destroy();
     });
   });
+
+  describe("parameter-set caching (individual NAL units, not whole events)", () => {
+    const START = Buffer.from([0x00, 0x00, 0x00, 0x01]);
+    const SPS_NAL = Buffer.from([0x67, 0x42, 0x00, 0x1e]);
+    const PPS_NAL = Buffer.from([0x68, 0xce, 0x3c, 0x80]);
+    // Distinctive payloads so we can detect which IDR ended up where.
+    const IDR_A = Buffer.from([0x65, 0xaa, 0xaa, 0xaa, 0xaa]);
+    const IDR_B = Buffer.from([0x65, 0xbb, 0xbb, 0xbb, 0xbb]);
+
+    const h264Metadata = {
+      videoCodec: "H264",
+      videoFPS: 30,
+      videoWidth: 1920,
+      videoHeight: 1080,
+    };
+
+    const fireVideo = (data: Buffer) => {
+      const handler = mockWsClient.addEventListener.mock.calls.find(
+        (c: any[]) => c[0] === "livestream video data",
+      )[1];
+      handler({
+        serialNumber: "TEST_DEVICE_123",
+        buffer: { data },
+        metadata: h264Metadata,
+      });
+    };
+
+    it("caches only the parameter-set NALs from a bundled SPS+PPS+IDR event", async () => {
+      await server.start();
+
+      // Eufy typically bundles parameter sets with the IDR in one event.
+      fireVideo(Buffer.concat([START, SPS_NAL, START, PPS_NAL, START, IDR_A]));
+      await wait(50);
+
+      // A new raw TCP client receives the cached headers on connect. It must
+      // get the SPS and PPS — and must NOT get the stale IDR frame.
+      const client = new net.Socket();
+      const received: Buffer[] = [];
+      client.on("data", (d) => received.push(d as Buffer));
+      await new Promise<void>((resolve) => {
+        client.connect(testPort, "127.0.0.1", () => resolve());
+      });
+      await wait(100);
+
+      const combined = Buffer.concat(received);
+      expect(combined.includes(SPS_NAL)).toBe(true);
+      expect(combined.includes(PPS_NAL)).toBe(true);
+      expect(combined.includes(IDR_A)).toBe(false);
+
+      client.destroy();
+    });
+
+    it("snapshot for a later IDR-only event does not embed the previous IDR", async () => {
+      // Frame A arrives bundled with the parameter sets.
+      fireVideo(Buffer.concat([START, SPS_NAL, START, PPS_NAL, START, IDR_A]));
+      await wait(20);
+
+      // A snapshot is requested, then frame B arrives as an IDR-only event
+      // (no parameter sets in the same event → the cached ones get prepended).
+      const snapshotPromise = server.captureSnapshot(3000);
+      await wait(20);
+      fireVideo(Buffer.concat([START, IDR_B]));
+
+      const payload = await snapshotPromise;
+
+      // Decodable: parameter sets present, followed by frame B.
+      expect(payload.includes(SPS_NAL)).toBe(true);
+      expect(payload.includes(PPS_NAL)).toBe(true);
+      expect(payload.includes(IDR_B)).toBe(true);
+      // Correct: the stale frame A must not precede frame B in the payload —
+      // ffmpeg decodes the FIRST picture it finds, which would be frame A.
+      expect(payload.includes(IDR_A)).toBe(false);
+    });
+  });
+
+  describe("stop() with muxer-only consumers", () => {
+    it("stops the upstream livestream even when no raw TCP clients exist", async () => {
+      // The normal HomeKit path: consumers attach only via the muxed port
+      // (zero raw TCP clients). stop() must still stop the camera.
+      const deviceApi = {
+        startLivestream: jest.fn().mockResolvedValue({}),
+        stopLivestream: jest.fn().mockResolvedValue({}),
+        isLivestreaming: jest.fn().mockResolvedValue({ livestreaming: true }),
+      };
+      const wsClient = {
+        addEventListener: jest.fn().mockReturnValue(() => {}),
+        commands: { device: jest.fn().mockReturnValue(deviceApi) },
+      };
+      const s = new StreamServer({
+        port: testPort + 1,
+        host: "127.0.0.1",
+        wsClient: wsClient as any,
+        serialNumber: "TEST_DEVICE_123",
+      });
+      await s.start();
+
+      // Attach a muxed client — this sets livestream intent.
+      const muxedPort = s.getMuxedPort()!;
+      const socket = net.createConnection({
+        port: muxedPort,
+        host: "127.0.0.1",
+      });
+      await new Promise((resolve) => socket.on("connect", resolve));
+      await wait(100);
+      expect((s as any).livestreamIntendedState).toBe(true);
+
+      await s.stop();
+
+      expect(deviceApi.stopLivestream).toHaveBeenCalled();
+      socket.destroy();
+    });
+  });
 });


### PR DESCRIPTION
Three correctness fixes from a deep review of the streaming path, each TDD'd.

## 1. Rate limiter was silently dropping livestream frames
`WebSocketMessageProcessor` capped ALL messages at 100/sec globally and discarded the excess. A single streaming camera produces ~15 video + ~40 ADTS audio events/sec, so two simultaneous streams (or one stream plus an event burst) exceeded the cap — dropped `LIVESTREAM_VIDEO_DATA` messages mean missing NAL units → corrupted/black video. This is a plausible contributor to the symptom family in #13/#23/#30. Livestream data and command results (dropping one strands its pending promise) are now exempt and don't consume the budget; the cap still applies to everything else.

## 2. Parameter-set cache held whole events, not NALs
`streamVideo` cached the entire event buffer whenever it contained an SPS/PPS/VPS. Eufy bundles parameter sets with the IDR in one event, so every cache slot held a full stale keyframe:
- new raw-TCP clients received up to 3 copies of an **old keyframe** ahead of the live stream, and
- the snapshot prepend path could place an old IDR before the fresh one — ffmpeg decodes the first picture it finds, so snapshots could show a stale frame.

The cache now stores the individual NAL re-framed with a start code.

## 3. `stop()` left the camera streaming
The upstream `stopLivestream` was gated on raw-TCP client count, but the normal HomeKit path attaches only muxed-port consumers (zero raw TCP clients) — so plugin reload/shutdown left the camera streaming until the upstream idled it out (battery drain on every restart). Now gated on `livestreamIntendedState`. Also clears the post-snapshot linger timer on stop.

## Tests
6 new tests (3 rate-limiter, 2 param-set cache, 1 stop gate) — all fail on the previous code. Full suites: stream-server 87/87, client 211 passed, monorepo build + all 4 packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)