### PR TITLE
perf: reduce per-frame cost in streaming hot path + TCP backpressure

### DIFF
--- a/packages/eufy-security-client/src/utils/websocket-message-processor.ts
+++ b/packages/eufy-security-client/src/utils/websocket-message-processor.ts
@@ -125,9 +125,14 @@ export class WebSocketMessageProcessor {
       return { valid: false, error: "Failed to convert message to string" };
     }
 
+    // Classify once — reused by both the rate limiter and the size filter.
+    // These `includes` calls scan the full payload string, so keep them to
+    // a single pass per message (video frames arrive 15-60×/sec/camera).
+    const isExempt = this.isRateLimitExempt(messageStr);
+
     // Rate limiting — stream data and command results are exempt and do not
     // consume the budget; the cap only applies to everything else.
-    if (!this.isRateLimitExempt(messageStr)) {
+    if (!isExempt) {
       if (!this.rateLimiter.canProcess()) {
         this.rateLimitedMessages++;
         this.logger?.warn("Message rate limit exceeded, dropping message");
@@ -135,79 +140,21 @@ export class WebSocketMessageProcessor {
       }
     }
 
-    // Smart message size filtering - allow important message types to be larger
+    // Size filtering — the only large messages accepted are stream data,
+    // command results (both covered by `isExempt`), and generic events.
     if (messageStr.length > this.maxMessageSize) {
-      // Try to extract message type for smart filtering
-      let messageType = "unknown";
-      let allowLargeMessage = false;
-
-      try {
-        // First check for livestream data using string matching (more reliable for large messages)
-        const isLivestreamData =
-          messageStr.includes(`"${DEVICE_EVENTS.LIVESTREAM_VIDEO_DATA}"`) ||
-          messageStr.includes(`"${DEVICE_EVENTS.LIVESTREAM_AUDIO_DATA}"`);
-
-        if (isLivestreamData) {
-          messageType = "livestream-data";
-          allowLargeMessage = true;
-        } else {
-          // Try to parse a preview for other message types
-          const preview = JSON.parse(messageStr.substring(0, 1000)); // Parse first 1KB
-          messageType = preview.type || preview.event?.event || "no-type";
-
-          // Allow large messages for other important types
-          const allowedLargeTypes = [MESSAGE_TYPES.EVENT, MESSAGE_TYPES.RESULT];
-
-          allowLargeMessage = allowedLargeTypes.some(
-            (type) =>
-              messageType.includes(type) ||
-              messageStr.includes(`"type":"${type}"`),
-          );
-        }
-      } catch (_e) {
-        // If we can't parse even the beginning, check if it's livestream data by string matching
-        const isLivestreamData =
-          messageStr.includes(`"${DEVICE_EVENTS.LIVESTREAM_VIDEO_DATA}"`) ||
-          messageStr.includes(`"${DEVICE_EVENTS.LIVESTREAM_AUDIO_DATA}"`);
-
-        if (isLivestreamData) {
-          messageType = "livestream-data";
-          allowLargeMessage = true;
-        } else {
-          // Also check for EVENT and RESULT types using string matching
-          const isEventMessage = messageStr.includes(
-            `"type":"${MESSAGE_TYPES.EVENT}"`,
-          );
-          const isResultMessage = messageStr.includes(
-            `"type":"${MESSAGE_TYPES.RESULT}"`,
-          );
-
-          if (isEventMessage) {
-            messageType = "event";
-            allowLargeMessage = true;
-          } else if (isResultMessage) {
-            messageType = "result";
-            allowLargeMessage = true;
-          } else {
-            messageType = "parse-error";
-            allowLargeMessage = false;
-          }
-        }
-      }
+      const allowLargeMessage =
+        isExempt || messageStr.includes(`"type":"${MESSAGE_TYPES.EVENT}"`);
 
       if (!allowLargeMessage) {
         this.invalidMessages++;
         this.logger?.warn(
           `Message too large and not streaming data: ${messageStr.length} bytes, ` +
-            `type: ${messageType}, preview: ${messageStr.substring(0, 100)}...`,
+            `preview: ${messageStr.substring(0, 100)}...`,
         );
         return { valid: false, error: "Message too large" };
-      } else {
-        // Log but allow the message
-        this.logger?.debug(
-          `Large message allowed for streaming: ${messageStr.length} bytes, type: ${messageType}`,
-        );
       }
+      this.logger?.debug(`Large message allowed: ${messageStr.length} bytes`);
     }
 
     // JSON parsing with validation

--- a/packages/eufy-stream-server/src/connection-manager.ts
+++ b/packages/eufy-stream-server/src/connection-manager.ts
@@ -41,6 +41,20 @@ export class ConnectionManager extends EventEmitter {
   private maxConnections: number;
 
   /**
+   * Max bytes allowed to sit unflushed in a client socket's write buffer.
+   * A consumer that stops reading (e.g. a wedged ffmpeg) would otherwise
+   * accumulate video frames in Node heap without bound; past this mark the
+   * client is considered stalled and is disconnected. Healthy local ffmpeg
+   * consumers drain far below this.
+   */
+  private static readonly MAX_BUFFERED_BYTES = 4 * 1024 * 1024;
+
+  /** True when the socket has too much unflushed data queued. */
+  private isStalled(socket: net.Socket): boolean {
+    return socket.writableLength > ConnectionManager.MAX_BUFFERED_BYTES;
+  }
+
+  /**
    * Creates a new ConnectionManager instance
    *
    * @param logger - Logger instance compatible with tslog's Logger<ILogObj> interface
@@ -173,6 +187,13 @@ export class ConnectionManager extends EventEmitter {
     }
 
     try {
+      if (this.isStalled(socket)) {
+        this.logger.warn(
+          `Client ${connectionId} stalled (${socket.writableLength} bytes buffered) — disconnecting`,
+        );
+        this.handleDisconnection(connectionId);
+        return false;
+      }
       if (socket.writable) {
         socket.write(data);
 
@@ -224,7 +245,12 @@ export class ConnectionManager extends EventEmitter {
 
     for (const [connectionId, socket] of this.connections) {
       try {
-        if (socket.writable) {
+        if (this.isStalled(socket)) {
+          this.logger.warn(
+            `Client ${connectionId} stalled (${socket.writableLength} bytes buffered) — disconnecting`,
+          );
+          this.handleDisconnection(connectionId);
+        } else if (socket.writable) {
           socket.write(data);
 
           // Update bytes written

--- a/packages/eufy-stream-server/src/h264-parser.ts
+++ b/packages/eufy-stream-server/src/h264-parser.ts
@@ -17,6 +17,46 @@
 import { Logger, ILogObj } from "tslog";
 import { NALUnit } from "./types";
 
+const H264_NAL_TYPE_NAMES: Record<number, string> = {
+  1: "P-slice",
+  2: "B-slice",
+  3: "I-slice",
+  5: "IDR-slice",
+  6: "SEI",
+  7: "SPS",
+  8: "PPS",
+  9: "AUD",
+  14: "Data Partitioning",
+};
+
+const HEVC_NAL_TYPE_NAMES: Record<number, string> = {
+  0: "TRAIL_N",
+  1: "TRAIL_R",
+  2: "TSA_N",
+  3: "TSA_R",
+  4: "STSA_N",
+  5: "STSA_R",
+  6: "RADL_N",
+  7: "RADL_R",
+  8: "RASL_N",
+  9: "RASL_R",
+  16: "BLA_W_LP",
+  17: "BLA_W_RADL",
+  18: "BLA_N_LP",
+  19: "IDR_W_RADL",
+  20: "IDR_N_LP",
+  21: "CRA_NUT",
+  32: "VPS_NUT",
+  33: "SPS_NUT",
+  34: "PPS_NUT",
+  35: "AUD_NUT",
+  36: "EOS_NUT",
+  37: "EOB_NUT",
+  38: "FD_NUT",
+  39: "PREFIX_SEI_NUT",
+  40: "SUFFIX_SEI_NUT",
+};
+
 export class H264Parser {
   private logger: Logger<ILogObj>;
 
@@ -132,18 +172,7 @@ export class H264Parser {
   }
 
   getNALTypeName(type: number): string {
-    const names: Record<number, string> = {
-      1: "P-slice",
-      2: "B-slice",
-      3: "I-slice",
-      5: "IDR-slice",
-      6: "SEI",
-      7: "SPS",
-      8: "PPS",
-      9: "AUD",
-      14: "Data Partitioning",
-    };
-    return names[type] ?? `Unknown(${type})`;
+    return H264_NAL_TYPE_NAMES[type] ?? `Unknown(${type})`;
   }
 
   // ─── H.265 / HEVC ──────────────────────────────────────────────────────────
@@ -206,33 +235,6 @@ export class H264Parser {
   }
 
   getNALTypeNameHevc(type: number): string {
-    const names: Record<number, string> = {
-      0: "TRAIL_N",
-      1: "TRAIL_R",
-      2: "TSA_N",
-      3: "TSA_R",
-      4: "STSA_N",
-      5: "STSA_R",
-      6: "RADL_N",
-      7: "RADL_R",
-      8: "RASL_N",
-      9: "RASL_R",
-      16: "BLA_W_LP",
-      17: "BLA_W_RADL",
-      18: "BLA_N_LP",
-      19: "IDR_W_RADL",
-      20: "IDR_N_LP",
-      21: "CRA_NUT",
-      32: "VPS_NUT",
-      33: "SPS_NUT",
-      34: "PPS_NUT",
-      35: "AUD_NUT",
-      36: "EOS_NUT",
-      37: "EOB_NUT",
-      38: "FD_NUT",
-      39: "PREFIX_SEI_NUT",
-      40: "SUFFIX_SEI_NUT",
-    };
-    return names[type] ?? `Unknown(${type})`;
+    return HEVC_NAL_TYPE_NAMES[type] ?? `Unknown(${type})`;
   }
 }

--- a/packages/eufy-stream-server/src/stream-server.ts
+++ b/packages/eufy-stream-server/src/stream-server.ts
@@ -1577,38 +1577,39 @@ export class StreamServer extends EventEmitter {
       this.videoMetadata?.videoCodec.toUpperCase() === "HEVC";
 
     try {
-      // Validate bitstream structure (start-code rules are identical for H.264 and H.265)
-      const isValid = isHevc
-        ? this.h264Parser.validateHevcData(data)
-        : this.h264Parser.validateH264Data(data);
+      // Single NAL scan per frame: extraction doubles as validation (an
+      // empty result means no valid Annex-B structure). This runs for
+      // every video event, so avoid scanning the buffer twice.
+      const nalUnits = isHevc
+        ? this.h264Parser.extractNALUnitsHevc(data)
+        : this.h264Parser.extractNALUnits(data);
 
-      if (!isValid) {
+      if (nalUnits.length === 0) {
         this.logger.warn(
           `Invalid ${isHevc ? "H.265" : "H.264"} data structure`,
         );
         return false;
       }
 
-      // Extract NAL units and detect keyframe using codec-appropriate logic
-      const nalUnits = isHevc
-        ? this.h264Parser.extractNALUnitsHevc(data)
-        : this.h264Parser.extractNALUnits(data);
-
       if (isKeyFrame === undefined) {
         isKeyFrame = nalUnits.some((nal) => nal.isKeyFrame);
       }
 
-      // Log NAL unit information for debugging
-      const nalInfo = nalUnits
-        .map((nal) =>
-          isHevc
-            ? `${this.h264Parser.getNALTypeNameHevc(nal.type)}(${nal.type})`
-            : `${this.h264Parser.getNALTypeName(nal.type)}(${nal.type})`,
-        )
-        .join(", ");
-      this.logger.debug(
-        `Processing ${isHevc ? "H.265" : "H.264"} data: ${data.length} bytes, NALs: [${nalInfo}], keyFrame: ${isKeyFrame}`,
-      );
+      // Log NAL unit information for debugging. Building the NAL-name
+      // string allocates per frame, so only do it when debug logging is
+      // actually enabled (tslog: 0=silly … 2=debug … 3=info).
+      if ((this.logger.settings?.minLevel ?? 3) <= 2) {
+        const nalInfo = nalUnits
+          .map((nal) =>
+            isHevc
+              ? `${this.h264Parser.getNALTypeNameHevc(nal.type)}(${nal.type})`
+              : `${this.h264Parser.getNALTypeName(nal.type)}(${nal.type})`,
+          )
+          .join(", ");
+        this.logger.debug(
+          `Processing ${isHevc ? "H.265" : "H.264"} data: ${data.length} bytes, NALs: [${nalInfo}], keyFrame: ${isKeyFrame}`,
+        );
+      }
 
       // Cache parameter-set NAL units so new clients can decode mid-stream.
       // H.264: SPS=7, PPS=8   H.265: VPS=32, SPS=33, PPS=34

--- a/packages/eufy-stream-server/tests/connection-manager.test.ts
+++ b/packages/eufy-stream-server/tests/connection-manager.test.ts
@@ -59,4 +59,61 @@ describe("ConnectionManager", () => {
       expect(disconnectListener).toHaveBeenCalledWith(connectionId);
     });
   });
+
+  describe("write backpressure", () => {
+    const setWritableLength = (socket: net.Socket, bytes: number) => {
+      // Unconnected test sockets report writable=false; force them
+      // writable so the backpressure check is what decides the outcome.
+      Object.defineProperty(socket, "writable", {
+        value: true,
+        configurable: true,
+      });
+      Object.defineProperty(socket, "writableLength", {
+        value: bytes,
+        configurable: true,
+      });
+    };
+
+    it("disconnects a client whose socket buffer exceeds the high-water mark", () => {
+      const stalled = makeSocket();
+      const writeSpy = jest.spyOn(stalled, "write").mockReturnValue(true);
+      manager.handleConnection(stalled);
+      // Simulate a consumer that stopped reading: bytes pile up in the
+      // kernel/Node buffer. Without a cap this grows without bound.
+      setWritableLength(stalled, 8 * 1024 * 1024);
+
+      const result = manager.broadcast(Buffer.from("frame"));
+
+      expect(result).toBe(false);
+      expect(writeSpy).not.toHaveBeenCalled();
+      expect(manager.getActiveConnectionCount()).toBe(0);
+    });
+
+    it("keeps writing to clients under the high-water mark", () => {
+      const healthy = makeSocket();
+      const writeSpy = jest.spyOn(healthy, "write").mockReturnValue(true);
+      manager.handleConnection(healthy);
+      setWritableLength(healthy, 1024);
+
+      const result = manager.broadcast(Buffer.from("frame"));
+
+      expect(result).toBe(true);
+      expect(writeSpy).toHaveBeenCalled();
+      expect(manager.getActiveConnectionCount()).toBe(1);
+    });
+
+    it("applies the same cap on sendToClient", () => {
+      const stalled = makeSocket();
+      const writeSpy = jest.spyOn(stalled, "write").mockReturnValue(true);
+      manager.handleConnection(stalled);
+      const connectionId = Object.keys(manager.getConnectionStats())[0];
+      setWritableLength(stalled, 8 * 1024 * 1024);
+
+      const result = manager.sendToClient(connectionId, Buffer.from("hdr"));
+
+      expect(result).toBe(false);
+      expect(writeSpy).not.toHaveBeenCalled();
+      expect(manager.getActiveConnectionCount()).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
Batch 3 from the deep review — hot-path optimizations (these run 15-60×/sec per streaming camera) plus one robustness guard.

- **Single NAL scan per frame**: `validate*Data()` ran a full `extractNALUnits` pass and then `streamVideo` extracted again — every frame was scanned twice. Extraction now doubles as validation (empty result = invalid), same observable behavior.
- **Debug strings gated on log level**: the per-frame NAL-name `map().join()` allocation now only happens when the logger is actually at debug level.
- **One-pass message classification**: the livestream/result exemption is computed once per WebSocket message and reused by both the rate limiter (added in #32) and the large-message filter — previously the large-message path did up to four full-payload `.includes()` scans plus a preview `JSON.parse`.
- **NAL type-name tables** moved to module constants (were rebuilt per call).
- **TCP write backpressure**: a client whose socket buffer exceeds 4 MB — a consumer that stopped reading, e.g. a wedged ffmpeg, which is exactly the failure mode this plugin battles — is disconnected instead of accumulating video frames in Node heap without bound. 3 new tests.

## Verification
New backpressure tests fail on the old code. Monorepo build, all 4 package suites, and lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)