### PR TITLE
feat: add H.265 compatibility streaming relay

### DIFF
--- a/.claude/skills/eufy-stream-test/SKILL.md
+++ b/.claude/skills/eufy-stream-test/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: eufy-stream-test
+description: >-
+  Test Eufy camera streams on the local network using this repo's
+  eufy-security-cli against the eufy-security-ws container. Use when asked to
+  list cameras, start/stop a camera stream, or verify that a camera's video
+  encoding (codec, resolution, frames) is actually working end-to-end. Default
+  WS host: ws://192.168.7.101:3000.
+---
+
+# Eufy Stream Test
+
+Verify Eufy cameras stream correctly over the LAN using the repo's CLI
+(`packages/eufy-security-cli`) talking to the running `eufy-security-ws`
+container.
+
+**Default WS host:** `ws://192.168.7.101:3000` (override with `--ws-host` when
+the user gives a different one).
+
+## What this validates
+
+The CLI's `device stream` serves the **raw H.264/H.265 elementary stream** and
+is **lazy** — the camera livestream only starts when a TCP client connects. So
+"encoding works" is proven by connecting a client (ffprobe) that both triggers
+the stream and reads back a real codec, resolution, and frames.
+
+This exercises the **camera → eufy-security-ws → NAL** pipeline and the
+negotiated codec. It does **not** exercise the Scrypted plugin's muxed fMP4 /
+transcode path.
+
+## Prerequisites
+
+- `node` and `ffprobe`/`ffmpeg` on PATH (ffmpeg is at `/opt/homebrew/bin` here).
+- CLI built. If `packages/eufy-security-cli/dist/main.js` is missing, the helper
+  script builds it automatically, or run:
+  `npm run build --workspace @caplaz/eufy-security-cli`
+- The `eufy-security-ws` container reachable at the WS host.
+
+All CLI commands take `--ws-host <ws://IP:PORT | IP:PORT>` (the `ws://` scheme is
+optional). Run the CLI as `node packages/eufy-security-cli/dist/main.js …`.
+
+## Workflow
+
+Run from the repo root: `/Users/ace/Projects/HA/eufy-security-scrypted`.
+
+### 1. Confirm the server is up
+
+```bash
+node packages/eufy-security-cli/dist/main.js driver status --ws-host ws://192.168.7.101:3000
+```
+
+Expect a connected/authenticated status. If it fails, the container is down or
+the host/credentials are wrong — stop and report that; streaming can't work.
+
+### 2. List cameras (get serials)
+
+```bash
+node packages/eufy-security-cli/dist/main.js device list --ws-host ws://192.168.7.101:3000
+```
+
+Output is grouped by device type with a `Serial: <serial>` line per device.
+Extract candidate camera serials with:
+
+```bash
+node packages/eufy-security-cli/dist/main.js device list --ws-host ws://192.168.7.101:3000 \
+  | grep 'Serial:' | awk '{print $2}'
+```
+
+`device list` connects, prints, and exits on its own — no cleanup needed.
+
+### 3. Test a camera's stream + encoding (start → verify → stop)
+
+Use the bundled helper — it starts the stream (default port 47989), connects
+ffprobe to trigger and validate the encoding, and always stops the stream and
+cleans up (even on Ctrl-C/error):
+
+```bash
+.claude/skills/eufy-stream-test/scripts/test-stream.sh \
+  --ws-host ws://192.168.7.101:3000 \
+  --camera-serial <SERIAL>
+```
+
+On success it prints the codec (`h264`/`hevc`), resolution, FPS, and the port,
+and exits 0. On failure it prints the CLI log tail and exits 1.
+
+Useful flags:
+- `--port PORT` (default 47989) — local TCP port for the stream; change it if
+  that port is busy.
+- `--probe-timeout SECS` (default 45) — raise for slow battery/4G cameras that
+  cold-start slowly.
+- `--hold SECS` — after verifying, keep the stream up this long so a player can
+  attach (see step 4).
+- `--verbose` — pass `--verbose` to the CLI and show its log tail.
+
+**Test all cameras:**
+
+```bash
+node packages/eufy-security-cli/dist/main.js device list --ws-host ws://192.168.7.101:3000 \
+  | grep 'Serial:' | awk '{print $2}' | while read -r SERIAL; do
+    echo "=== $SERIAL ==="
+    .claude/skills/eufy-stream-test/scripts/test-stream.sh \
+      --ws-host ws://192.168.7.101:3000 --camera-serial "$SERIAL" \
+      || echo "FAILED: $SERIAL"
+  done
+```
+
+### 4. Watch a stream manually (optional)
+
+To eyeball a feed, hold the stream open and attach a player:
+
+```bash
+.claude/skills/eufy-stream-test/scripts/test-stream.sh \
+  --ws-host ws://192.168.7.101:3000 --camera-serial <SERIAL> --hold 60
+# then, in another terminal, while it holds:
+ffplay tcp://127.0.0.1:<PORT>   # PORT is printed by the helper
+```
+
+Or run the CLI directly (serves until Ctrl-C) and connect a player yourself:
+
+```bash
+node packages/eufy-security-cli/dist/main.js device stream \
+  --ws-host ws://192.168.7.101:3000 --camera-serial <SERIAL> --port 8090
+# another terminal:
+ffplay tcp://127.0.0.1:8090
+```
+
+Suggest the user type `! <command>` in the prompt for interactive players like
+`ffplay`, so their output lands in this session.
+
+## Manual one-shot validation (no helper script)
+
+If you need to do it by hand — remember the stream is lazy, so a client must
+connect. Start the stream in the background on a fixed port, then probe it:
+
+```bash
+node packages/eufy-security-cli/dist/main.js device stream \
+  --ws-host ws://192.168.7.101:3000 --camera-serial <SERIAL> --port 8090 &
+CLI_PID=$!
+sleep 3   # let the TCP server open
+ffprobe -v error -rw_timeout 45000000 -analyzeduration 20M -probesize 20M \
+  -i tcp://127.0.0.1:8090 -select_streams v:0 \
+  -show_entries stream=codec_name,width,height,avg_frame_rate \
+  -read_intervals "%+#60" -of default=noprint_wrappers=1
+kill -INT $CLI_PID   # graceful stop (runs the CLI's cleanup)
+```
+
+A raw HEVC stream that auto-detection misses needs `-f hevc` before `-i`.
+
+## Interpreting results
+
+- **`codec_name=h264` or `hevc` with a real `width`x`height`** → encoding works;
+  the camera, ws server, and NAL parsing are all healthy.
+- **"No decodable video within Ns"** → the client connected but no keyframe
+  arrived. Causes: camera offline/asleep (raise `--probe-timeout`), wrong serial,
+  a non-camera device (sensors don't stream), or an H.265 camera whose stream
+  the ws server can't deliver. Re-run with `--verbose` and read the CLI log tail.
+- **CLI exits before "stream ready"** → bad `--ws-host`, container down, or
+  auth/2FA needed. Check `driver status` first.
+
+## Notes
+
+- `device list`, `device info`, and `driver status` self-terminate. `device
+  stream` and `device monitor` run until SIGINT — the helper always sends it;
+  if you run the CLI directly, stop it with Ctrl-C (or `kill -INT <pid>`).
+- The stream flag is `--port` / `-p` (not `--tcp-port`; the CLI README is stale).
+- The CLI maps `--port 0` to **8080** (not a random port), so always pass an
+  explicit port. The bound port is echoed as `🌐 TCP Server: localhost:<port>`.
+
+## Verified working
+
+Tested against `ws://192.168.7.101:3000` — both cameras stream H.264:
+`Front Door` (T8124) 1280x720@25 and `Backyard` (T8423) 2304x1296@25. The helper
+starts, verifies, and tears down cleanly with no orphaned processes.

--- a/.claude/skills/eufy-stream-test/scripts/test-stream.sh
+++ b/.claude/skills/eufy-stream-test/scripts/test-stream.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+#
+# test-stream.sh — start a Eufy camera stream via the repo CLI, validate that
+# the video encoding is actually flowing (codec/resolution/frames via ffprobe),
+# then stop it cleanly.
+#
+# The CLI's `device stream` serves the RAW H.264/H.265 elementary stream and is
+# LAZY: the camera livestream only starts once a TCP client connects. This
+# script provides that client (ffprobe), which both triggers the stream and
+# verifies the encoding. It validates the camera -> eufy-security-ws -> NAL
+# pipeline and the negotiated codec; it does NOT exercise the Scrypted plugin's
+# muxed fMP4 / transcode path.
+#
+# Usage:
+#   test-stream.sh --ws-host HOST --camera-serial SERIAL [options]
+#
+# Options:
+#   --ws-host, -w HOST          eufy-security-ws host (ws://IP:PORT or IP:PORT)   [required]
+#   --camera-serial, -c SERIAL  Camera serial (from `device list`)                [required]
+#   --port, -p PORT             Local TCP port for the stream (default: 47989).
+#                               Change it if that port is busy. (The CLI maps
+#                               --port 0 to 8080, so this script uses an explicit
+#                               port instead.)
+#   --probe-timeout SECS        Max wait for first video data (default: 45).
+#                               Battery/4G cameras cold-start slowly; keep this
+#                               generous.
+#   --hold SECS                 After a successful probe, keep the stream server
+#                               up this long so you can attach ffplay/vlc
+#                               manually (default: 0 = stop immediately).
+#   --verbose                   Pass --verbose to the CLI and show its log tail.
+#   --help, -h                  Show this help.
+#
+# Exit codes: 0 = encoding verified, 1 = failure (no port / no video / bad codec).
+
+set -u
+
+# ---- resolve paths -----------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# skill lives at <repo>/.claude/skills/eufy-stream-test/scripts, so repo root is 5 up
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+CLI_ENTRY="$REPO_ROOT/packages/eufy-security-cli/dist/main.js"
+
+WS_HOST=""
+CAMERA_SERIAL=""
+PORT=47989
+PROBE_TIMEOUT=45
+HOLD=0
+VERBOSE=""
+
+die() { echo "❌ $*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --ws-host|-w)         WS_HOST="${2:-}"; shift 2 ;;
+    --camera-serial|-c)   CAMERA_SERIAL="${2:-}"; shift 2 ;;
+    --port|-p)            PORT="${2:-}"; shift 2 ;;
+    --probe-timeout)      PROBE_TIMEOUT="${2:-}"; shift 2 ;;
+    --hold)               HOLD="${2:-}"; shift 2 ;;
+    --verbose)            VERBOSE="--verbose"; shift ;;
+    --help|-h)            sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) die "Unknown argument: $1 (use --help)" ;;
+  esac
+done
+
+[ -n "$WS_HOST" ]       || die "Missing --ws-host (e.g. ws://192.168.7.101:3000)"
+[ -n "$CAMERA_SERIAL" ] || die "Missing --camera-serial (run: device list)"
+command -v ffprobe >/dev/null 2>&1 || die "ffprobe not found (install ffmpeg)"
+command -v node >/dev/null 2>&1    || die "node not found"
+
+# ---- build CLI if needed -----------------------------------------------------
+if [ ! -f "$CLI_ENTRY" ]; then
+  echo "ℹ️  CLI not built; building @caplaz/eufy-security-cli ..."
+  ( cd "$REPO_ROOT" && npm run build --workspace @caplaz/eufy-security-cli ) \
+    || die "CLI build failed"
+  [ -f "$CLI_ENTRY" ] || die "CLI build did not produce $CLI_ENTRY"
+fi
+
+# ---- launch the stream (lazy: starts on client connect) ----------------------
+STREAM_LOG="$(mktemp -t eufy-stream.XXXXXX)"
+STREAM_PID=""
+
+cleanup() {
+  if [ -n "$STREAM_PID" ] && kill -0 "$STREAM_PID" 2>/dev/null; then
+    kill -INT "$STREAM_PID" 2>/dev/null   # graceful: triggers CLI cleanup()
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+      kill -0 "$STREAM_PID" 2>/dev/null || break
+      sleep 0.5
+    done
+    kill -9 "$STREAM_PID" 2>/dev/null || true
+  fi
+  rm -f "$STREAM_LOG" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+echo "🎥 Starting stream: camera=$CAMERA_SERIAL via $WS_HOST (tcp port $PORT)"
+node "$CLI_ENTRY" device stream \
+  --ws-host "$WS_HOST" \
+  --camera-serial "$CAMERA_SERIAL" \
+  --port "$PORT" $VERBOSE >"$STREAM_LOG" 2>&1 &
+STREAM_PID=$!
+
+# ---- wait for the TCP server to be ready (bound on our port) -----------------
+READY=""
+for _ in $(seq 1 40); do   # up to ~20s to open the TCP server
+  if ! kill -0 "$STREAM_PID" 2>/dev/null; then
+    echo "❌ CLI exited before the stream was ready (port $PORT in use? bad serial?). Log:" >&2
+    tail -n 30 "$STREAM_LOG" >&2
+    exit 1
+  fi
+  # Either the connection banner or the "TCP server started on port N" log line
+  # confirms the socket is bound and accepting.
+  if grep -qE "localhost:$PORT|TCP server started on port $PORT" "$STREAM_LOG" 2>/dev/null; then
+    READY=1; break
+  fi
+  sleep 0.5
+done
+[ -n "$READY" ] || { echo "❌ Timed out waiting for the TCP server. Log:" >&2; tail -n 30 "$STREAM_LOG" >&2; exit 1; }
+echo "🌐 Stream server on tcp://127.0.0.1:$PORT — connecting ffprobe (triggers camera)…"
+
+# ---- probe the raw stream ----------------------------------------------------
+# Connecting is what starts the camera livestream; a cold battery/4G camera may
+# take tens of seconds to deliver the first keyframe, hence -rw_timeout.
+RW_TIMEOUT_US=$(( PROBE_TIMEOUT * 1000000 ))
+
+probe() { # echoes "codec|width|height|fps"
+  # Auto-detect ONLY. Forcing "-f h264"/"-f hevc" makes ffprobe report that
+  # codec even on the wrong data (a false positive, betrayed by 0x0 size), so
+  # we never force — ffmpeg's raw-ES probe reliably tells H.264 from HEVC.
+  ffprobe -v error \
+    -rw_timeout "$RW_TIMEOUT_US" \
+    -analyzeduration 20M -probesize 20M \
+    -i "tcp://127.0.0.1:$PORT" \
+    -select_streams v:0 \
+    -show_entries stream=codec_name,width,height,avg_frame_rate \
+    -read_intervals "%+#60" \
+    -of default=noprint_wrappers=1:nokey=1 2>/dev/null \
+    | paste -sd'|' -
+}
+
+# A PASS requires a known codec AND real dimensions (proof of a decoded SPS,
+# not just a demuxer guess). Retry once: ffprobe can connect before the stream
+# server has sent cached parameter sets; the second attempt hits a warm stream.
+CODEC=""; WIDTH=""; HEIGHT=""; FPS=""
+for attempt in 1 2; do
+  RESULT="$(probe)"
+  CODEC="$(echo "$RESULT"  | cut -d'|' -f1)"
+  WIDTH="$(echo "$RESULT"  | cut -d'|' -f2 | grep -oE '^[0-9]+' || true)"
+  HEIGHT="$(echo "$RESULT" | cut -d'|' -f3 | grep -oE '^[0-9]+' || true)"
+  FPS="$(echo "$RESULT"    | cut -d'|' -f4)"
+  if { [ "$CODEC" = "h264" ] || [ "$CODEC" = "hevc" ]; } \
+     && [ "${WIDTH:-0}" -gt 0 ] 2>/dev/null && [ "${HEIGHT:-0}" -gt 0 ] 2>/dev/null; then
+    break
+  fi
+  CODEC=""  # not a valid detection; retry
+  sleep 2
+done
+
+if [ -z "$CODEC" ]; then
+  echo "❌ No decodable video with valid dimensions within ${PROBE_TIMEOUT}s." >&2
+  echo "   (camera offline/asleep, wrong serial, or a non-camera device?)" >&2
+  echo "   CLI log tail:" >&2
+  tail -n 30 "$STREAM_LOG" >&2
+  exit 1
+fi
+
+echo ""
+echo "============================================================"
+echo "✅ ENCODING VERIFIED"
+echo "   Camera : $CAMERA_SERIAL"
+echo "   Codec  : $CODEC"
+echo "   Size   : ${WIDTH}x${HEIGHT}"
+echo "   FPS    : ${FPS:-unknown}"
+echo "   Port   : tcp://127.0.0.1:$PORT"
+echo "============================================================"
+
+# ---- optional hold for manual viewing ---------------------------------------
+if [ "${HOLD:-0}" -gt 0 ] 2>/dev/null; then
+  echo ""
+  echo "⏸️  Holding stream ${HOLD}s — attach a player now:"
+  echo "     ffplay tcp://127.0.0.1:$PORT"
+  echo "     vlc    tcp://127.0.0.1:$PORT"
+  sleep "$HOLD"
+fi
+
+echo "🛑 Stopping stream…"
+exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,36 @@ jobs:
             packages/eufy-security-client/junit.xml
           retention-days: 30
 
+  ffmpeg-integration:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          cache: "npm"
+
+      - name: Install FFmpeg
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes ffmpeg
+
+      - name: Require FFmpeg H.264 and H.265 encoders
+        run: |
+          ffmpeg -hide_banner -encoders | grep --quiet 'libx264'
+          ffmpeg -hide_banner -encoders | grep --quiet 'libx265'
+          ffprobe -version
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Run H.264 compatibility relay FFmpeg integration test
+        run: cd packages/eufy-stream-server && npm test -- tests/h264-compatibility-relay.integration.test.ts --runInBand
+
   quality:
     runs-on: ubuntu-latest
     needs: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Optional H.265 compatibility stream**: The plugin now distinguishes the
+  truthful native `p2p` stream from the strictly H.264 `p2p-h264` compatibility
+  stream. `Auto` transcodes only verified H.265 interactive live views and
+  keeps recorder/prebuffer destinations native; `Force` requires compatibility
+  for verified H.265; and `Native` always preserves the source stream. Unknown
+  codecs are never guessed or relabelled. Explicit `p2p-h264` requests fail
+  rather than silently falling back when verification or encoder admission is
+  unavailable.
+- **Compatibility encoder admission controls**: Compatibility transcodes are
+  capacity-accounted per active encoder, including continuously running
+  prebuffers. New admissions are thermally gated at 85 °C and resume at 75 °C;
+  the gate does not terminate an encoder already running and is inert on hosts
+  without a usable temperature reading. Except for a continuous prebuffer, an
+  encoder is not retained beyond its consumer lifecycle and configured linger.
 - **eufy-security-ws 3.1.0 / schema 21 support** (#35): Typed client support for the schema-21 PTZ preset commands (`device.preset_position`, `device.save_preset_position`, `device.delete_preset_position`) via `presetPosition()` / `savePresetPosition()` / `deletePresetPosition()` on the device command builder. New upstream device models are recognized with correct capabilities and names: HomeBase Mini (T8025), NVR S4 Max (T8N00), PoE Bullet-PTZ Cam S4 (T8E00), Camera S4 / SoloCam E42 / 4G LTE Cam S330 as battery PTZ cameras, FamiLock S3 (T85V0) as a battery dual video doorbell + lock, FamiLock E34 (T85P0), Smart Lock C33/C30, Motion Sensor E20, Siren E20, and the Water and Freeze Sensor (T8920). The development Docker Compose image is pinned to `bropat/eufy-security-ws:3.1.0`.
 - **Per-HomeBase stream coordination** (#28): A Eufy HomeBase serves only one camera P2P stream at a time. A new station stream coordinator serializes `startLivestream` across cameras on the same HomeBase — live view preempts with a clean stop-before-start handoff ("newest tap wins"), a warm-up guard absorbs the Home-app grid's burst of simultaneous requests, and background work never interrupts a viewer.
 - **Wedge detection and automatic station recovery** (#28): Cold-start (no first frame within 18s) and mid-session (15s data stall) watchdogs detect a wedged upstream P2P session, recycle the station connection (`station.disconnect`/`connect`), and automatically restart the livestream for waiting consumers — no more plugin restarts to recover a dead stream. Suppression guards (no-signal, chronic-failure, busy-sibling) protect healthy cameras on a shared HomeBase from recycle storms.
@@ -40,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Deprecated `debug` option on `StreamServerOptions`** (#33): logger `minLevel` has controlled verbosity for a long time.
 - Internal dead module `device-manifest-builder.ts` (#33) — zero imports; manifest building lives in `DeviceUtils`.
 
-*Thanks to [@josha](https://github.com/josha) for the shared-HomeBase reliability work (#28).*
+_Thanks to [@josha](https://github.com/josha) for the shared-HomeBase reliability work (#28)._
 
 ## [0.3.1] - 2026-04-20
 
@@ -50,7 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Device Support**: ensure standalone devices route through EufyStation by defaulting providerNativeId to station_<serial>
+- **Device Support**: ensure standalone devices route through EufyStation by defaulting providerNativeId to station\_<serial>
 - **Error Handling**: use Promise.allSettled so one bad device doesn't block all others (#22)
 - **State Updates**: guard against state updates before device initialization (#17)
 
@@ -95,7 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Wrong FFmpeg demuxer for H.265**: Streams always passed `-f h264` to FFmpeg regardless of camera codec; H.265 cameras now correctly use `-f hevc`
 - **`providerNativeId=undefined` edge case**: `registerDevicesFromServerState` now handles stations with an undefined `providerNativeId` without throwing
 
-*Thanks to [@DTse](https://github.com/DTse) for contributing audio streaming and intercom support.*
+_Thanks to [@DTse](https://github.com/DTse) for contributing audio streaming and intercom support._
 
 ## [0.2.1] - 2025-10-26
 

--- a/packages/eufy-security-scrypted/README.md
+++ b/packages/eufy-security-scrypted/README.md
@@ -114,7 +114,9 @@ After installation, configure the plugin with:
 
 - **WebSocket URL**: URL of your eufy-security-ws server (default: `ws://localhost:3000`)
 - **Debug Logging**: Enable verbose logging for troubleshooting
-- **Memory Management**: Configure memory thresholds for optimal performance
+- **H.265 Compatibility Mode**: Choose `Auto` (the default), `Force`, or
+  `Native` for the optional H.265-to-H.264 compatibility stream. See
+  [Native and compatibility streams](#native-and-compatibility-streams).
 
 ## Device Support
 
@@ -382,13 +384,74 @@ Eufy Camera → eufy-security-ws → WebSocket → Scrypted Plugin → TCP Serve
 ✅ **Keyframe Detection** - Fast stream initialization  
 ✅ **Auto Cleanup** - Resources freed when not streaming
 
+### Native and Compatibility Streams
+
+The plugin exposes two stable P2P stream contracts:
+
+| Stream ID  | Contract                                                                                                                                                                     |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `p2p`      | Native P2P video. It does not start a compatibility encoder and reports the camera's actual verified codec (`H264` or `H265`); an H.265 source is never relabelled as H.264. |
+| `p2p-h264` | Compatibility video. It is available only after a verified H.265 source is admitted to the compatibility encoder, and its output contract is H.264.                          |
+
+An explicit `p2p` request is always native, regardless of mode. An explicit
+`p2p-h264` request is strict: it fails with an actionable selection error when
+the source codec is not verified H.265 or an encoder cannot be admitted. It
+never silently falls back to `p2p`.
+
+| Mode     | Default routing behavior                                                                                                                                                                                                                                                                                 |
+| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Auto`   | Uses `p2p-h264` only for a verified H.265 source sent to an interactive local or remote live-view destination and only when an encoder is available. All other destinations, including local and remote recorders, remain native. Unknown or unverified codecs remain native; the plugin does not guess. |
+| `Force`  | Uses compatibility H.264 for a verified H.265 source. A verified native H.264 source remains native. Missing codec verification or unavailable encoder capacity returns an error instead of guessing or relabelling the stream.                                                                          |
+| `Native` | Always uses `p2p`; no compatibility encoder is requested.                                                                                                                                                                                                                                                |
+
+#### Capacity, prebuffer, and thermal admission
+
+Each active compatibility transcode consumes one encoder slot and CPU capacity.
+Plan capacity for the sum of continuously running compatibility prebuffers and
+the peak number of interactive compatibility viewers, rather than only the
+number of cameras. A continuous prebuffer holds its encoder slot and CPU for
+as long as it is enabled.
+
+Except for a continuous compatibility prebuffer, a compatibility encoder is
+created only for an active consumer and may remain during the configured
+post-consumer linger. It is not kept running outside that lifecycle. Native
+`p2p` streams never consume a compatibility encoder slot.
+
+The thermal governor gates new compatibility encoder admissions at 85 °C and
+allows new admissions again only at or below 75 °C (with admission-triggered
+sampling at most once every 30 seconds). It deliberately does not terminate an
+encoder that is already running. When the host does not expose a usable
+temperature reading, or reading it fails, the gate is inert, so it is a safety
+limit rather than a guarantee that every platform will prevent overheating.
+
 ### Stream Quality
 
 - **Resolution**: Up to 2K (device dependent)
-- **Codec**: H.264 (hardware accelerated)
+- **Codec**: Native H.264 or H.265; the optional `p2p-h264` compatibility
+  stream is H.264
 - **Audio**: AAC stereo
 - **Latency**: ~1-3 seconds (typical)
 - **Bandwidth**: 2-5 Mbps (variable)
+
+### Verification and CI
+
+The automated tests cover stream selection (`Auto`, `Force`, `Native`, explicit
+stream IDs, recorder routing, and unverified codecs), thermal hysteresis and
+concurrent admission checks, and the FFmpeg input configuration handed to
+Scrypted. A real-FFmpeg HEVC-to-H.264 integration test also verifies that an
+H.265 input can be decoded and emitted as decodable H.264. It self-skips on a
+developer machine when FFmpeg or the required encoders are unavailable.
+
+The dedicated FFmpeg CI job requires FFmpeg with the x264 and x265 encoders, so
+the integration test is exercised in CI instead of being hidden by the local
+skip. It validates the conversion pipeline, not a physical camera; still test
+`p2p-h264` with a live verified H.265 camera before relying on it in production.
+
+GitHub Actions installs dependencies and the Scrypted SDK, then runs the root
+build and test suites on Node.js 18, 20, and 22. Its quality job additionally
+type-checks, lints, and formats the client package. Run `npm run build`,
+`npm run test`, `npm run lint`, and `npm run format:check` locally before
+submitting changes.
 
 ---
 

--- a/packages/eufy-security-scrypted/src/eufy-device.ts
+++ b/packages/eufy-security-scrypted/src/eufy-device.ts
@@ -977,6 +977,10 @@ export class EufyDevice
             `💾 Persisted detected video codec: ${normalized} (was: ${previous ?? "unset"})`,
           );
         }
+        // Stream options are codec-bearing. Once a live session replaces a
+        // persisted hint, ask Scrypted to obtain fresh options so consumers
+        // cannot continue to select a stale native codec description.
+        this.onDeviceEvent(ScryptedInterface.VideoCamera, undefined);
       },
     );
 

--- a/packages/eufy-security-scrypted/src/eufy-device.ts
+++ b/packages/eufy-security-scrypted/src/eufy-device.ts
@@ -86,6 +86,7 @@ import {
   StreamService,
   StateChangeEvent,
 } from "./services/device";
+import { CompatibilityMode } from "./services/device/stream-selector";
 import { PropertyMapper } from "./utils/property-mapper";
 import {
   acquireStationSlot,
@@ -102,6 +103,12 @@ import {
 } from "./utils/thumbnail-refresh";
 
 const THUMBNAIL_REFRESH_SETTING_KEY = "thumbnailRefreshInterval";
+const COMPATIBILITY_MODE_SETTING_KEY = "compatibilityMode";
+const COMPATIBILITY_MODE_CHOICES: CompatibilityMode[] = [
+  "Auto",
+  "Force",
+  "Native",
+];
 import { VideoClipsService } from "./services/video";
 import { PtzControlService, LightControlService } from "./services/control";
 
@@ -309,6 +316,7 @@ export class EufyDevice
       this.serialNumber,
       this.streamServer,
       this.logger,
+      { compatibilityMode: () => this.getCompatibilityMode() },
     );
     this.ptzControlService = new PtzControlService(
       deviceApi,
@@ -497,6 +505,20 @@ export class EufyDevice
       group: "Streaming",
     });
 
+    settings.push({
+      key: COMPATIBILITY_MODE_SETTING_KEY,
+      title: "H.264 Compatibility Mode",
+      description:
+        "Auto uses the H.264 relay only for a live, verified H.265 source " +
+        "when a compatibility stream is requested. Force requires that relay " +
+        "for verified H.265 sources; Native always keeps the camera's native " +
+        "codec. The relay consumes host CPU and can increase prebuffer startup " +
+        "time, so Auto is the recommended default.",
+      value: this.getCompatibilityMode(),
+      choices: COMPATIBILITY_MODE_CHOICES,
+      group: "Streaming",
+    });
+
     return settings;
   }
 
@@ -509,6 +531,22 @@ export class EufyDevice
     if (key === THUMBNAIL_REFRESH_SETTING_KEY) {
       this.storage.setItem(key, String(value));
       this.logger.info(`🖼️  Background thumbnail refresh set to: ${value}`);
+      return;
+    }
+
+    if (key === COMPATIBILITY_MODE_SETTING_KEY) {
+      if (
+        typeof value !== "string" ||
+        !COMPATIBILITY_MODE_CHOICES.includes(value as CompatibilityMode)
+      ) {
+        throw new Error(
+          `Invalid H.264 compatibility mode: ${String(value)}`,
+        );
+      }
+      this.storage.setItem(key, value);
+      this.logger.info(`🎬 H.264 compatibility mode set to: ${value}`);
+      this.onDeviceEvent(ScryptedInterface.VideoCamera, undefined);
+      this.onDeviceEvent(ScryptedInterface.Settings, undefined);
       return;
     }
 
@@ -976,11 +1014,10 @@ export class EufyDevice
           this.logger.info(
             `💾 Persisted detected video codec: ${normalized} (was: ${previous ?? "unset"})`,
           );
+          // Stream options carry the source codec. A live session may replace
+          // a persisted startup hint, so ask Scrypted to fetch fresh options.
+          this.onDeviceEvent(ScryptedInterface.VideoCamera, undefined);
         }
-        // Stream options are codec-bearing. Once a live session replaces a
-        // persisted hint, ask Scrypted to obtain fresh options so consumers
-        // cannot continue to select a stale native codec description.
-        this.onDeviceEvent(ScryptedInterface.VideoCamera, undefined);
       },
     );
 
@@ -1018,6 +1055,15 @@ export class EufyDevice
     this.logger.debug(
       "Stream server created with WebSocket client integration",
     );
+  }
+
+  private getCompatibilityMode(): CompatibilityMode {
+    const stored = this.storage.getItem(
+      COMPATIBILITY_MODE_SETTING_KEY,
+    ) as CompatibilityMode | null;
+    return stored === "Auto" || stored === "Force" || stored === "Native"
+      ? stored
+      : "Auto";
   }
 
   /**

--- a/packages/eufy-security-scrypted/src/eufy-provider.ts
+++ b/packages/eufy-security-scrypted/src/eufy-provider.ts
@@ -53,8 +53,24 @@ import { Logger, ILogObj, ILogObjMeta } from "tslog";
 import { EufyStation } from "./eufy-station";
 import { DeviceUtils } from "./utils/device-utils";
 import { getCurrentMemoryUsageMB } from "./utils/memory-manager";
+import {
+  CompatibilityStreamingConfig,
+  configureSharedCompatibilityStreaming,
+  DEFAULT_COMPATIBILITY_STREAMING_CONFIG,
+} from "./services/device/stream-service";
 
 const { deviceManager } = sdk;
+
+const COMPATIBILITY_ENCODER_CAPACITY_SETTING = "compatibilityEncoderCapacity";
+const COMPATIBILITY_ENCODER_CRITICAL_TEMPERATURE_SETTING =
+  "compatibilityEncoderCriticalTemperatureC";
+const COMPATIBILITY_ENCODER_RECOVERY_TEMPERATURE_SETTING =
+  "compatibilityEncoderRecoveryTemperatureC";
+const COMPATIBILITY_ENCODER_SETTING_KEYS = new Set([
+  COMPATIBILITY_ENCODER_CAPACITY_SETTING,
+  COMPATIBILITY_ENCODER_CRITICAL_TEMPERATURE_SETTING,
+  COMPATIBILITY_ENCODER_RECOVERY_TEMPERATURE_SETTING,
+]);
 
 /**
  * Create a transport function for routing tslog output to a Scrypted console
@@ -127,6 +143,7 @@ export class EufySecurityProvider
       type: "hidden",
     });
     this.logger.attachTransport(createConsoleTransport(this.console));
+    this.applyCompatibilityStreamingConfiguration();
 
     // Create a logger for the WebSocket client using the same console
     // (WebSocket events are part of the provider's responsibility)
@@ -206,6 +223,37 @@ export class EufySecurityProvider
         value: `${currentMemory}MB`,
         type: "string",
         readonly: true,
+      },
+
+      {
+        group: "Advanced H.264 Compatibility",
+        key: COMPATIBILITY_ENCODER_CAPACITY_SETTING,
+        title: "Maximum Compatibility Encoders",
+        description:
+          "Maximum simultaneous H.265-to-H.264 relay encoders shared by all cameras. " +
+          "Higher values use more CPU; the conservative default is 1.",
+        value: this.getCompatibilityStreamingConfiguration().encoderCapacity,
+        type: "number",
+      },
+      {
+        group: "Advanced H.264 Compatibility",
+        key: COMPATIBILITY_ENCODER_CRITICAL_TEMPERATURE_SETTING,
+        title: "Encoder Critical Temperature (°C)",
+        description:
+          "Deny new compatibility encoders at or above this temperature. Existing streams are not stopped.",
+        value:
+          this.getCompatibilityStreamingConfiguration().criticalTemperatureC,
+        type: "number",
+      },
+      {
+        group: "Advanced H.264 Compatibility",
+        key: COMPATIBILITY_ENCODER_RECOVERY_TEMPERATURE_SETTING,
+        title: "Encoder Recovery Temperature (°C)",
+        description:
+          "Allow new compatibility encoders again once the host cools to this temperature. It must be lower than the critical temperature.",
+        value:
+          this.getCompatibilityStreamingConfiguration().recoveryTemperatureC,
+        type: "number",
       },
 
       // Eufy Cloud Account Settings
@@ -417,6 +465,16 @@ export class EufySecurityProvider
    * @returns {Promise<void>}
    */
   async putSetting(key: string, value: SettingValue): Promise<void> {
+    if (COMPATIBILITY_ENCODER_SETTING_KEYS.has(key)) {
+      const configuration = this.getCompatibilityStreamingConfiguration({
+        [key]: value,
+      });
+      configureSharedCompatibilityStreaming(configuration);
+      this.storage.setItem(key, String(value));
+      this.onDeviceEvent(ScryptedInterface.Settings, undefined);
+      return;
+    }
+
     // Handle button clicks (they can have null values)
     if (key === "connectDriver") {
       this.logger.info("🔗 Button clicked: Connect to Eufy cloud");
@@ -642,6 +700,54 @@ export class EufySecurityProvider
       // Refresh the settings UI to reflect the immediate change
       this.onDeviceEvent(ScryptedInterface.Settings, undefined);
     }
+  }
+
+  private applyCompatibilityStreamingConfiguration(): void {
+    configureSharedCompatibilityStreaming(
+      this.getCompatibilityStreamingConfiguration(),
+    );
+  }
+
+  private getCompatibilityStreamingConfiguration(
+    overrides: Record<string, SettingValue> = {},
+  ): CompatibilityStreamingConfig {
+    const read = (key: string, fallback: number): number => {
+      const value = overrides[key] ?? this.storage.getItem(key);
+      const parsed =
+        typeof value === "number"
+          ? value
+          : typeof value === "string" && value.trim() !== ""
+            ? Number(value)
+            : undefined;
+      return parsed !== undefined && Number.isFinite(parsed) ? parsed : fallback;
+    };
+    const configuration = {
+      encoderCapacity: read(
+        COMPATIBILITY_ENCODER_CAPACITY_SETTING,
+        DEFAULT_COMPATIBILITY_STREAMING_CONFIG.encoderCapacity,
+      ),
+      criticalTemperatureC: read(
+        COMPATIBILITY_ENCODER_CRITICAL_TEMPERATURE_SETTING,
+        DEFAULT_COMPATIBILITY_STREAMING_CONFIG.criticalTemperatureC,
+      ),
+      recoveryTemperatureC: read(
+        COMPATIBILITY_ENCODER_RECOVERY_TEMPERATURE_SETTING,
+        DEFAULT_COMPATIBILITY_STREAMING_CONFIG.recoveryTemperatureC,
+      ),
+    };
+    if (
+      !Number.isInteger(configuration.encoderCapacity) ||
+      configuration.encoderCapacity < 1 ||
+      configuration.recoveryTemperatureC >= configuration.criticalTemperatureC
+    ) {
+      if (Object.keys(overrides).length) {
+        throw new Error(
+          "Encoder capacity must be a positive integer and recovery temperature must be lower than critical temperature.",
+        );
+      }
+      return { ...DEFAULT_COMPATIBILITY_STREAMING_CONFIG };
+    }
+    return configuration;
   }
   async getRefreshFrequency(): Promise<number> {
     return 300; // 5 minutes

--- a/packages/eufy-security-scrypted/src/eufy-provider.ts
+++ b/packages/eufy-security-scrypted/src/eufy-provider.ts
@@ -711,6 +711,8 @@ export class EufySecurityProvider
   private getCompatibilityStreamingConfiguration(
     overrides: Record<string, SettingValue> = {},
   ): CompatibilityStreamingConfig {
+    const hasOverride = (key: string) =>
+      Object.prototype.hasOwnProperty.call(overrides, key);
     const read = (key: string, fallback: number): number => {
       const value = overrides[key] ?? this.storage.getItem(key);
       const parsed =
@@ -719,7 +721,11 @@ export class EufySecurityProvider
           : typeof value === "string" && value.trim() !== ""
             ? Number(value)
             : undefined;
-      return parsed !== undefined && Number.isFinite(parsed) ? parsed : fallback;
+      if (parsed !== undefined && Number.isFinite(parsed)) return parsed;
+      if (hasOverride(key)) {
+        throw new Error(`${key} must be a finite number.`);
+      }
+      return fallback;
     };
     const configuration = {
       encoderCapacity: read(
@@ -738,9 +744,21 @@ export class EufySecurityProvider
     if (
       !Number.isInteger(configuration.encoderCapacity) ||
       configuration.encoderCapacity < 1 ||
+      configuration.criticalTemperatureC < 0 ||
+      configuration.criticalTemperatureC > 125 ||
+      configuration.recoveryTemperatureC < 0 ||
+      configuration.recoveryTemperatureC > 125 ||
       configuration.recoveryTemperatureC >= configuration.criticalTemperatureC
     ) {
       if (Object.keys(overrides).length) {
+        if (
+          configuration.criticalTemperatureC < 0 ||
+          configuration.criticalTemperatureC > 125 ||
+          configuration.recoveryTemperatureC < 0 ||
+          configuration.recoveryTemperatureC > 125
+        ) {
+          throw new Error("Encoder temperatures must be between 0 and 125.");
+        }
         throw new Error(
           "Encoder capacity must be a positive integer and recovery temperature must be lower than critical temperature.",
         );

--- a/packages/eufy-security-scrypted/src/eufy-provider.ts
+++ b/packages/eufy-security-scrypted/src/eufy-provider.ts
@@ -714,7 +714,9 @@ export class EufySecurityProvider
     const hasOverride = (key: string) =>
       Object.prototype.hasOwnProperty.call(overrides, key);
     const read = (key: string, fallback: number): number => {
-      const value = overrides[key] ?? this.storage.getItem(key);
+      const value = hasOverride(key)
+        ? overrides[key]
+        : this.storage.getItem(key);
       const parsed =
         typeof value === "number"
           ? value

--- a/packages/eufy-security-scrypted/src/services/device/stream-selector.ts
+++ b/packages/eufy-security-scrypted/src/services/device/stream-selector.ts
@@ -1,0 +1,144 @@
+/**
+ * Pure stream routing policy for native and compatibility streams.
+ *
+ * This module deliberately does not start streams, inspect codec metadata, or
+ * request encoder admission. Its caller supplies only verified facts so the
+ * selection cannot guess a source codec or silently relabel a native stream.
+ */
+
+export type CompatibilityMode = "Auto" | "Force" | "Native";
+
+export type SourceCodec = "H264" | "H265";
+
+export interface StreamSelectionInput {
+  /** A requested Scrypted stream id. Only `p2p` and `p2p-h264` are special. */
+  streamId?: string;
+  /** Scrypted's intended consumer destination. Unknown values are native. */
+  destination?: string;
+  compatibilityMode: CompatibilityMode;
+  /** Codec information supplied by the stream server, not inferred here. */
+  source: {
+    codec?: SourceCodec;
+    verified: boolean;
+  };
+  /** Why a compatibility encoder cannot be admitted, if it cannot. */
+  availabilityError?: string;
+}
+
+export interface NativeStreamSelection {
+  kind: "stream";
+  streamId: "p2p";
+}
+
+export interface CompatibilityStreamSelection {
+  kind: "stream";
+  streamId: "p2p-h264";
+}
+
+export type CompatibilitySelectionReason =
+  | "source-codec-unverified"
+  | "source-codec-not-h265"
+  | "compatibility-unavailable";
+
+export interface CompatibilityStreamSelectionError {
+  kind: "error";
+  /** Stable name suitable for logs and user-facing error handling. */
+  name: "CompatibilityStreamSelectionError";
+  mode: CompatibilityMode;
+  reason: CompatibilitySelectionReason;
+  source: StreamSelectionInput["source"];
+  /** `available` or the supplied admission/encoder error. */
+  availability: string;
+  message: string;
+}
+
+export type StreamSelection =
+  | NativeStreamSelection
+  | CompatibilityStreamSelection
+  | CompatibilityStreamSelectionError;
+
+const NATIVE_STREAM: NativeStreamSelection = {
+  kind: "stream",
+  streamId: "p2p",
+};
+const COMPATIBILITY_STREAM: CompatibilityStreamSelection = {
+  kind: "stream",
+  streamId: "p2p-h264",
+};
+const INTERACTIVE_LIVE_DESTINATIONS = new Set(["local", "remote"]);
+
+/**
+ * Select either the truthful native P2P stream or a guaranteed compatibility
+ * H.264 stream. Explicit stream ids take precedence; destination is only an
+ * Auto-mode default-routing hint.
+ */
+export function selectStream(input: StreamSelectionInput): StreamSelection {
+  if (input.streamId === "p2p") {
+    return NATIVE_STREAM;
+  }
+
+  if (input.streamId === "p2p-h264") {
+    return selectCompatibilityStream(input);
+  }
+
+  if (input.compatibilityMode === "Native") {
+    return NATIVE_STREAM;
+  }
+
+  if (input.compatibilityMode === "Force") {
+    return input.source.codec === "H264" && input.source.verified
+      ? NATIVE_STREAM
+      : selectCompatibilityStream(input);
+  }
+
+  if (
+    input.source.verified &&
+    input.source.codec === "H265" &&
+    INTERACTIVE_LIVE_DESTINATIONS.has(input.destination ?? "")
+  ) {
+    // Auto mode may remain native when the optional compatibility path is not
+    // available. Only an explicit compatibility request or Force is strict.
+    return input.availabilityError ? NATIVE_STREAM : COMPATIBILITY_STREAM;
+  }
+
+  return NATIVE_STREAM;
+}
+
+function selectCompatibilityStream(
+  input: StreamSelectionInput,
+): CompatibilityStreamSelection | CompatibilityStreamSelectionError {
+  if (!input.source.verified) {
+    return selectionError(input, "source-codec-unverified");
+  }
+
+  if (input.source.codec !== "H265") {
+    return selectionError(input, "source-codec-not-h265");
+  }
+
+  if (input.availabilityError) {
+    return selectionError(input, "compatibility-unavailable");
+  }
+
+  return COMPATIBILITY_STREAM;
+}
+
+function selectionError(
+  input: StreamSelectionInput,
+  reason: CompatibilitySelectionReason,
+): CompatibilityStreamSelectionError {
+  const availability = input.availabilityError ?? "available";
+  const codec = input.source.codec ?? "unknown";
+
+  return {
+    kind: "error",
+    name: "CompatibilityStreamSelectionError",
+    mode: input.compatibilityMode,
+    reason,
+    source: { ...input.source },
+    availability,
+    message:
+      `Cannot select the compatibility H.264 stream: mode=${input.compatibilityMode}; ` +
+      `reason=${reason}; source=${codec} (${input.source.verified ? "verified" : "unverified"}); ` +
+      `availability=${availability}.`,
+  };
+}

--- a/packages/eufy-security-scrypted/src/services/device/stream-service.ts
+++ b/packages/eufy-security-scrypted/src/services/device/stream-service.ts
@@ -36,6 +36,10 @@ export interface StreamConfig {
   codec?: string;
 }
 
+function escapeStreamRequestLogField(value?: string): string {
+  return (value ?? "<none>").replace(/\r/g, "\\r").replace(/\n/g, "\\n");
+}
+
 /**
  * StreamService handles video streaming operations
  *
@@ -119,7 +123,7 @@ export class StreamService {
     options?: RequestMediaStreamOptions,
   ): Promise<MediaObject> {
     this.logger.info(
-      `[stream-request] id=${options?.id ?? "<none>"} destination=${(options as any)?.destination ?? "<none>"} tool=${(options as any)?.tool ?? "<none>"}`,
+      `[stream-request] id=${escapeStreamRequestLogField(options?.id)} destination=${escapeStreamRequestLogField(options?.destination)} tool=${escapeStreamRequestLogField(options?.tool)}`,
     );
     this.logger.info("Getting video stream, starting stream server if needed");
 

--- a/packages/eufy-security-scrypted/src/services/device/stream-service.ts
+++ b/packages/eufy-security-scrypted/src/services/device/stream-service.ts
@@ -70,8 +70,38 @@ export interface StreamServiceOptions {
 }
 
 const METADATA_BOOTSTRAP_TIMEOUT_MS = 15_000;
+export const DEFAULT_COMPATIBILITY_STREAMING_CONFIG = {
+  encoderCapacity: 1,
+  criticalTemperatureC: 85,
+  recoveryTemperatureC: 75,
+} as const;
+
+export interface CompatibilityStreamingConfig {
+  encoderCapacity: number;
+  criticalTemperatureC: number;
+  recoveryTemperatureC: number;
+}
+
 let sharedEncoderPool: CompatibilityEncoderPool | undefined;
 let defaultThermalGovernor: ThermalGovernor | undefined;
+
+/**
+ * Replace the process-wide admission controls used by compatibility relays.
+ * Existing relays retain their acquired lease; the new limits apply to relays
+ * started after this call.
+ */
+export function configureSharedCompatibilityStreaming(
+  config: CompatibilityStreamingConfig,
+): void {
+  validateCompatibilityStreamingConfig(config);
+  sharedEncoderPool = new CompatibilityEncoderPool({
+    capacity: config.encoderCapacity,
+  });
+  defaultThermalGovernor = new ThermalGovernor({
+    criticalTemperatureC: config.criticalTemperatureC,
+    recoveryTemperatureC: config.recoveryTemperatureC,
+  });
+}
 
 function getSharedEncoderPool(): CompatibilityEncoderPool {
   return (sharedEncoderPool ??= new CompatibilityEncoderPool());
@@ -79,6 +109,25 @@ function getSharedEncoderPool(): CompatibilityEncoderPool {
 
 function getDefaultThermalGovernor(): ThermalGovernor {
   return (defaultThermalGovernor ??= new ThermalGovernor());
+}
+
+function validateCompatibilityStreamingConfig(
+  config: CompatibilityStreamingConfig,
+): void {
+  if (!Number.isInteger(config.encoderCapacity) || config.encoderCapacity < 1) {
+    throw new RangeError("encoderCapacity must be a positive integer");
+  }
+  if (!Number.isFinite(config.criticalTemperatureC)) {
+    throw new RangeError("criticalTemperatureC must be a finite number");
+  }
+  if (!Number.isFinite(config.recoveryTemperatureC)) {
+    throw new RangeError("recoveryTemperatureC must be a finite number");
+  }
+  if (config.recoveryTemperatureC >= config.criticalTemperatureC) {
+    throw new RangeError(
+      "recoveryTemperatureC must be lower than criticalTemperatureC",
+    );
+  }
 }
 
 function escapeStreamRequestLogField(value?: string): string {

--- a/packages/eufy-security-scrypted/src/services/device/stream-service.ts
+++ b/packages/eufy-security-scrypted/src/services/device/stream-service.ts
@@ -94,16 +94,20 @@ export function configureSharedCompatibilityStreaming(
   config: CompatibilityStreamingConfig,
 ): void {
   validateCompatibilityStreamingConfig(config);
-  sharedEncoderPool = new CompatibilityEncoderPool({
-    capacity: config.encoderCapacity,
-  });
+  if (sharedEncoderPool) {
+    sharedEncoderPool.setCapacity(config.encoderCapacity);
+  } else {
+    sharedEncoderPool = new CompatibilityEncoderPool({
+      capacity: config.encoderCapacity,
+    });
+  }
   defaultThermalGovernor = new ThermalGovernor({
     criticalTemperatureC: config.criticalTemperatureC,
     recoveryTemperatureC: config.recoveryTemperatureC,
   });
 }
 
-function getSharedEncoderPool(): CompatibilityEncoderPool {
+export function getSharedCompatibilityEncoderPool(): CompatibilityEncoderPool {
   return (sharedEncoderPool ??= new CompatibilityEncoderPool());
 }
 
@@ -122,6 +126,14 @@ function validateCompatibilityStreamingConfig(
   }
   if (!Number.isFinite(config.recoveryTemperatureC)) {
     throw new RangeError("recoveryTemperatureC must be a finite number");
+  }
+  if (
+    config.criticalTemperatureC < 0 ||
+    config.criticalTemperatureC > 125 ||
+    config.recoveryTemperatureC < 0 ||
+    config.recoveryTemperatureC > 125
+  ) {
+    throw new RangeError("temperatures must be between 0 and 125");
   }
   if (config.recoveryTemperatureC >= config.criticalTemperatureC) {
     throw new RangeError(
@@ -495,7 +507,8 @@ export class StreamService {
     startedExclusively: boolean;
   }> {
     if (!this.relay) {
-      const encoderPool = this.encoderPool ?? getSharedEncoderPool();
+      const encoderPool =
+        this.encoderPool ?? getSharedCompatibilityEncoderPool();
       const relayFactory =
         this.relayFactory ??
         ((relayOptions) =>

--- a/packages/eufy-security-scrypted/src/services/device/stream-service.ts
+++ b/packages/eufy-security-scrypted/src/services/device/stream-service.ts
@@ -204,6 +204,8 @@ export class StreamService {
     }
 
     let bootstrap: MetadataBootstrapWaiter | undefined;
+    let handoff: (() => void) | undefined;
+    let relayStarted = false;
     try {
       const resolved = await this.resolveCurrentSource();
       bootstrap = resolved.bootstrap;
@@ -215,13 +217,16 @@ export class StreamService {
       }
 
       if (selection.streamId === "p2p-h264") {
+        // The relay attaches to the muxed source during start(). Register the
+        // handoff first so that real attach cannot race past the bootstrap.
+        handoff = this.handoffBootstrapOnConsumerAttach(bootstrap);
         const relayPort = await this.ensureCompatibilityRelay();
+        relayStarted = true;
         const media = await this.createCompatibilityMediaObject(
           relayPort,
           quality,
           options,
         );
-        this.handoffBootstrapOnConsumerAttach(bootstrap);
         return media;
       }
 
@@ -234,10 +239,20 @@ export class StreamService {
         quality,
         options,
       );
-      this.handoffBootstrapOnConsumerAttach(bootstrap);
+      handoff = this.handoffBootstrapOnConsumerAttach(bootstrap);
       return media;
     } catch (error) {
-      bootstrap?.cancel();
+      if (relayStarted) {
+        try {
+          await this.stopCompatibilityRelay();
+        } catch (stopError) {
+          this.logger.warn(
+            `Failed to clean up H.264 compatibility relay for ${this.serialNumber}: ${stopError}`,
+          );
+        }
+      }
+      if (handoff) handoff();
+      else bootstrap?.cancel();
       throw error;
     }
   }
@@ -249,10 +264,7 @@ export class StreamService {
    */
   async stopStream(): Promise<void> {
     this.releaseBootstrapHandoffs();
-    if (this.relay) {
-      await this.relay.stop();
-      this.relay = undefined;
-    }
+    await this.stopCompatibilityRelay();
     if (this.streamServerStarted) {
       this.logger.info("Stopping stream server");
       await this.streamServer.stop();
@@ -529,20 +541,31 @@ export class StreamService {
 
   private handoffBootstrapOnConsumerAttach(
     bootstrap?: MetadataBootstrapWaiter,
-  ): void {
-    if (!bootstrap) return;
+  ): (() => void) | undefined {
+    if (!bootstrap) return undefined;
     let removeListener: () => void = () => undefined;
+    let released = false;
     const release = () => {
+      if (released) return;
+      released = true;
       removeListener();
       this.bootstrapHandoffs.delete(release);
       bootstrap.release();
     };
     removeListener = this.streamServer.onNextConsumerAttached(release);
     this.bootstrapHandoffs.add(release);
+    return release;
   }
 
   private releaseBootstrapHandoffs(): void {
     for (const release of [...this.bootstrapHandoffs]) release();
+  }
+
+  private async stopCompatibilityRelay(): Promise<void> {
+    if (!this.relay) return;
+    const relay = this.relay;
+    this.relay = undefined;
+    await relay.stop();
   }
 
   /**

--- a/packages/eufy-security-scrypted/src/services/device/stream-service.ts
+++ b/packages/eufy-security-scrypted/src/services/device/stream-service.ts
@@ -15,9 +15,20 @@ import {
 } from "@scrypted/sdk";
 import sdk from "@scrypted/sdk";
 import { VideoQuality } from "@caplaz/eufy-security-client";
+import {
+  CompatibilityEncoderPool,
+  getSharedH264CompatibilityRelay,
+  H264CompatibilityRelay,
+  ThermalGovernor,
+} from "@caplaz/eufy-stream-server";
 import { FFmpegUtils } from "../../utils/ffmpeg-utils";
 import { Logger, ILogObj } from "tslog";
-import { IStreamServer } from "./types";
+import {
+  selectStream,
+  CompatibilityMode,
+  SourceCodec,
+} from "./stream-selector";
+import { IStreamServer, MetadataBootstrapWaiter } from "./types";
 
 /**
  * Video dimensions based on quality
@@ -36,6 +47,40 @@ export interface StreamConfig {
   codec?: string;
 }
 
+interface CompatibilityRelay {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  getPort(): number | undefined;
+}
+
+export interface StreamServiceOptions {
+  compatibilityMode?: () => CompatibilityMode;
+  thermalGovernor?: Pick<
+    ThermalGovernor,
+    "checkCompatibilityEncoderAdmission" | "getStatus"
+  >;
+  encoderPool?: CompatibilityEncoderPool;
+  relayFactory?: (options: {
+    serialNumber: string;
+    streamServer: IStreamServer;
+    ffmpegPath: string;
+    pool: CompatibilityEncoderPool;
+  }) => CompatibilityRelay;
+  metadataTimeoutMs?: number;
+}
+
+const METADATA_BOOTSTRAP_TIMEOUT_MS = 15_000;
+let sharedEncoderPool: CompatibilityEncoderPool | undefined;
+let defaultThermalGovernor: ThermalGovernor | undefined;
+
+function getSharedEncoderPool(): CompatibilityEncoderPool {
+  return (sharedEncoderPool ??= new CompatibilityEncoderPool());
+}
+
+function getDefaultThermalGovernor(): ThermalGovernor {
+  return (defaultThermalGovernor ??= new ThermalGovernor());
+}
+
 function escapeStreamRequestLogField(value?: string): string {
   return (value ?? "<none>").replace(/\r/g, "\\r").replace(/\n/g, "\\n");
 }
@@ -51,12 +96,31 @@ function escapeStreamRequestLogField(value?: string): string {
  */
 export class StreamService {
   private streamServerStarted = false;
+  private relay?: CompatibilityRelay;
+  private resolvedFfmpegPath?: string;
+  private readonly bootstrapHandoffs = new Set<() => void>();
+  private readonly compatibilityMode: () => CompatibilityMode;
+  private readonly thermalGovernor?: Pick<
+    ThermalGovernor,
+    "checkCompatibilityEncoderAdmission" | "getStatus"
+  >;
+  private readonly encoderPool?: CompatibilityEncoderPool;
+  private readonly relayFactory?: StreamServiceOptions["relayFactory"];
+  private readonly metadataTimeoutMs: number;
 
   constructor(
     private serialNumber: string,
     private streamServer: IStreamServer,
     private logger: Logger<ILogObj>,
-  ) {}
+    options: StreamServiceOptions = {},
+  ) {
+    this.compatibilityMode = options.compatibilityMode ?? (() => "Auto");
+    this.thermalGovernor = options.thermalGovernor;
+    this.encoderPool = options.encoderPool;
+    this.relayFactory = options.relayFactory;
+    this.metadataTimeoutMs =
+      options.metadataTimeoutMs ?? METADATA_BOOTSTRAP_TIMEOUT_MS;
+  }
 
   /**
    * Get video dimensions based on quality setting
@@ -87,23 +151,28 @@ export class StreamService {
    */
   getVideoStreamOptions(quality?: VideoQuality): ResponseMediaStreamOptions[] {
     const { width, height } = this.getVideoDimensions(quality);
-    const codec = FFmpegUtils.toScryptedCodec(
-      this.streamServer.getVideoMetadata()?.videoCodec ?? "H264",
-    );
+    const source = this.currentVerifiedSource();
+    const audio = this.truthfulAudioOption();
+    const native: ResponseMediaStreamOptions = {
+      id: "p2p",
+      name: "P2P Stream",
+      container: "mp4",
+      video: source.codec
+        ? { codec: FFmpegUtils.toScryptedCodec(source.codec), width, height }
+        : { width, height },
+      ...(audio && { audio }),
+    };
+
+    if (source.codec !== "H265") return [native];
 
     return [
+      native,
       {
-        id: "p2p",
-        name: "P2P Stream",
+        id: "p2p-h264",
+        name: "P2P Stream (H.264 Compatibility)",
         container: "mp4",
-        video: {
-          codec,
-          width,
-          height,
-        },
-        audio: {
-          codec: "aac",
-        },
+        video: { codec: "h264", width, height },
+        ...(audio && { audio }),
       },
     ];
   }
@@ -134,17 +203,43 @@ export class StreamService {
       this.logger.info("Stream server started");
     }
 
-    const port = this.streamServer.getPort();
-    if (!port) {
-      throw new Error("Failed to get stream server port");
+    let bootstrap: MetadataBootstrapWaiter | undefined;
+    try {
+      const resolved = await this.resolveCurrentSource();
+      bootstrap = resolved.bootstrap;
+      const selection = await this.select(resolved.codec, options);
+
+      if (selection.kind === "error") {
+        this.logger.warn(selection.message);
+        throw new Error(selection.message);
+      }
+
+      if (selection.streamId === "p2p-h264") {
+        const relayPort = await this.ensureCompatibilityRelay();
+        const media = await this.createCompatibilityMediaObject(
+          relayPort,
+          quality,
+          options,
+        );
+        this.handoffBootstrapOnConsumerAttach(bootstrap);
+        return media;
+      }
+
+      const port = this.streamServer.getPort();
+      if (!port) throw new Error("Failed to get stream server port");
+      this.logger.info(`Stream server is listening on port ${port}`);
+      const media = await this.createNativeMediaObject(
+        port,
+        resolved.codec,
+        quality,
+        options,
+      );
+      this.handoffBootstrapOnConsumerAttach(bootstrap);
+      return media;
+    } catch (error) {
+      bootstrap?.cancel();
+      throw error;
     }
-
-    this.logger.info(`Stream server is listening on port ${port}`);
-    this.logger.info(
-      "Creating MediaObject with fallback dimensions (metadata will be updated when stream starts)",
-    );
-
-    return await this.createOptimizedMediaObject(port, quality, options);
   }
 
   /**
@@ -153,6 +248,11 @@ export class StreamService {
    * @returns Promise that resolves when stream is stopped
    */
   async stopStream(): Promise<void> {
+    this.releaseBootstrapHandoffs();
+    if (this.relay) {
+      await this.relay.stop();
+      this.relay = undefined;
+    }
     if (this.streamServerStarted) {
       this.logger.info("Stopping stream server");
       await this.streamServer.stop();
@@ -181,17 +281,15 @@ export class StreamService {
    * @param options - Request options from Scrypted
    * @returns MediaObject configured for FFmpeg
    */
-  private async createOptimizedMediaObject(
+  private async createNativeMediaObject(
     port: number,
+    sourceCodec: SourceCodec,
     quality: VideoQuality | undefined,
     options?: RequestMediaStreamOptions,
   ): Promise<MediaObject> {
     const { width, height } = this.getVideoDimensions(quality);
 
-    // Detect codec from last received stream metadata; default to H264
-    const eufyCodec =
-      this.streamServer.getVideoMetadata()?.videoCodec ?? "H264";
-    const scryptedCodec = FFmpegUtils.toScryptedCodec(eufyCodec); // "h264" or "h265"
+    const scryptedCodec = FFmpegUtils.toScryptedCodec(sourceCodec);
 
     // Use the muxed fMP4 port if available. The stream server runs an
     // in-process JMuxer (no ffmpeg subprocess) that consumes raw H.264
@@ -229,7 +327,7 @@ export class StreamService {
           "-probesize",
           "5000000",
           "-f",
-          FFmpegUtils.toFFmpegFormat(eufyCodec),
+          FFmpegUtils.toFFmpegFormat(sourceCodec),
           "-i",
           `tcp://127.0.0.1:${port}`,
           "-an",
@@ -253,11 +351,198 @@ export class StreamService {
           width,
           height,
         },
-        ...(useMuxed && { audio: { codec: "aac" } }),
+        ...(useMuxed &&
+          this.truthfulAudioOption() && {
+            audio: this.truthfulAudioOption(),
+          }),
       },
     };
 
     return await sdk.mediaManager.createFFmpegMediaObject(ffmpegInput);
+  }
+
+  private currentVerifiedSource(): { codec?: SourceCodec; verified: boolean } {
+    if (!this.streamServer.isMetadataVerifiedForCurrentSession()) {
+      return { verified: false };
+    }
+    const codec = this.toSourceCodec(
+      this.streamServer.getVideoMetadata()?.videoCodec,
+    );
+    return { codec, verified: !!codec };
+  }
+
+  private async resolveCurrentSource(): Promise<{
+    codec: SourceCodec;
+    bootstrap?: MetadataBootstrapWaiter;
+  }> {
+    const current = this.currentVerifiedSource();
+    if (current.codec) return { codec: current.codec };
+
+    const bootstrap = this.streamServer.acquireMetadataWaiter(
+      this.metadataTimeoutMs,
+    );
+    try {
+      const metadata = await bootstrap.promise;
+      const codec = this.toSourceCodec(metadata.videoCodec);
+      if (!codec || !this.streamServer.isMetadataVerifiedForCurrentSession()) {
+        throw new Error(
+          "Live video metadata was received without a verified source codec",
+        );
+      }
+      return { codec, bootstrap };
+    } catch (error) {
+      bootstrap.cancel();
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Unable to determine the current live video codec for ${this.serialNumber}. ` +
+          `Wait for the camera to deliver video and retry. (${detail})`,
+      );
+    }
+  }
+
+  private async select(
+    codec: SourceCodec,
+    options?: RequestMediaStreamOptions,
+  ) {
+    const input = {
+      streamId: options?.id,
+      destination: options?.destination,
+      compatibilityMode: this.compatibilityMode(),
+      source: { codec, verified: true },
+    };
+    let selection = selectStream(input);
+    if (selection.kind !== "stream" || selection.streamId !== "p2p-h264") {
+      return selection;
+    }
+
+    const thermalGovernor = this.thermalGovernor ?? getDefaultThermalGovernor();
+    const admitted = await thermalGovernor.checkCompatibilityEncoderAdmission();
+    if (admitted) return selection;
+    const status = thermalGovernor.getStatus();
+    const availabilityError = `thermal admission denied (${status.reason}${
+      status.temperatureC === undefined ? "" : ` at ${status.temperatureC}°C`
+    })`;
+    this.logger.warn(
+      `Cannot start H.264 compatibility stream for ${this.serialNumber}: ${availabilityError}`,
+    );
+    selection = selectStream({ ...input, availabilityError });
+    return selection;
+  }
+
+  private async ensureCompatibilityRelay(): Promise<number> {
+    if (!this.relay) {
+      const encoderPool = this.encoderPool ?? getSharedEncoderPool();
+      const relayFactory =
+        this.relayFactory ??
+        ((relayOptions) =>
+          getSharedH264CompatibilityRelay(
+            relayOptions,
+          ) as H264CompatibilityRelay);
+      this.relay = relayFactory({
+        serialNumber: this.serialNumber,
+        streamServer: this.streamServer,
+        ffmpegPath: await this.resolveFfmpegPath(),
+        pool: encoderPool,
+      });
+    }
+    try {
+      await this.relay.start();
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        `Cannot start H.264 compatibility relay for ${this.serialNumber}: ${detail}`,
+      );
+      throw new Error(
+        `H.264 compatibility stream is unavailable for ${this.serialNumber}: ${detail}`,
+      );
+    }
+    const port = this.relay.getPort();
+    if (!port) {
+      throw new Error(
+        `H.264 compatibility relay started without a listening port for ${this.serialNumber}`,
+      );
+    }
+    return port;
+  }
+
+  private async resolveFfmpegPath(): Promise<string> {
+    if (this.resolvedFfmpegPath) return this.resolvedFfmpegPath;
+    try {
+      this.resolvedFfmpegPath = await sdk.mediaManager.getFFmpegPath();
+    } catch {
+      this.resolvedFfmpegPath = "ffmpeg";
+    }
+    return this.resolvedFfmpegPath;
+  }
+
+  private async createCompatibilityMediaObject(
+    port: number,
+    quality: VideoQuality | undefined,
+    options?: RequestMediaStreamOptions,
+  ): Promise<MediaObject> {
+    const { width, height } = this.getVideoDimensions(quality);
+    return sdk.mediaManager.createFFmpegMediaObject({
+      url: undefined,
+      inputArguments: this.createMuxedInputArguments(port),
+      mediaStreamOptions: {
+        id: options?.id || "p2p-h264",
+        name: options?.name || "Eufy Camera Stream (H.264 Compatibility)",
+        container: "mp4",
+        video: { ...options?.video, codec: "h264", width, height },
+        ...(this.truthfulAudioOption() && {
+          audio: this.truthfulAudioOption(),
+        }),
+      },
+    });
+  }
+
+  private createMuxedInputArguments(port: number): string[] {
+    return [
+      "-hide_banner",
+      "-loglevel",
+      "error",
+      "-fflags",
+      "+genpts+nobuffer",
+      "-analyzeduration",
+      "2000000",
+      "-probesize",
+      "1000000",
+      "-f",
+      "mp4",
+      "-i",
+      `tcp://127.0.0.1:${port}`,
+    ];
+  }
+
+  private truthfulAudioOption(): { codec: "aac" } | undefined {
+    return this.streamServer.getAudioStatus() === "aac"
+      ? { codec: "aac" }
+      : undefined;
+  }
+
+  private toSourceCodec(codec?: string): SourceCodec | undefined {
+    const normalized = codec?.toUpperCase();
+    if (normalized === "H264" || normalized === "AVC") return "H264";
+    if (normalized === "H265" || normalized === "HEVC") return "H265";
+    return undefined;
+  }
+
+  private handoffBootstrapOnConsumerAttach(
+    bootstrap?: MetadataBootstrapWaiter,
+  ): void {
+    if (!bootstrap) return;
+    let removeListener: () => void = () => undefined;
+    const release = () => {
+      removeListener();
+      this.bootstrapHandoffs.delete(release);
+      bootstrap.release();
+    };
+    removeListener = this.streamServer.onNextConsumerAttached(release);
+    this.bootstrapHandoffs.add(release);
+  }
+
+  private releaseBootstrapHandoffs(): void {
+    for (const release of [...this.bootstrapHandoffs]) release();
   }
 
   /**

--- a/packages/eufy-security-scrypted/src/services/device/stream-service.ts
+++ b/packages/eufy-security-scrypted/src/services/device/stream-service.ts
@@ -118,6 +118,9 @@ export class StreamService {
     quality: VideoQuality | undefined,
     options?: RequestMediaStreamOptions,
   ): Promise<MediaObject> {
+    this.logger.info(
+      `[stream-request] id=${options?.id ?? "<none>"} destination=${(options as any)?.destination ?? "<none>"} tool=${(options as any)?.tool ?? "<none>"}`,
+    );
     this.logger.info("Getting video stream, starting stream server if needed");
 
     if (!this.streamServerStarted) {

--- a/packages/eufy-security-scrypted/src/services/device/stream-service.ts
+++ b/packages/eufy-security-scrypted/src/services/device/stream-service.ts
@@ -205,7 +205,7 @@ export class StreamService {
 
     let bootstrap: MetadataBootstrapWaiter | undefined;
     let handoff: (() => void) | undefined;
-    let relayStarted = false;
+    let relayStartedExclusively = false;
     try {
       const resolved = await this.resolveCurrentSource();
       bootstrap = resolved.bootstrap;
@@ -220,10 +220,10 @@ export class StreamService {
         // The relay attaches to the muxed source during start(). Register the
         // handoff first so that real attach cannot race past the bootstrap.
         handoff = this.handoffBootstrapOnConsumerAttach(bootstrap);
-        const relayPort = await this.ensureCompatibilityRelay();
-        relayStarted = true;
+        const relay = await this.ensureCompatibilityRelay();
+        relayStartedExclusively = relay.startedExclusively;
         const media = await this.createCompatibilityMediaObject(
-          relayPort,
+          relay.port,
           quality,
           options,
         );
@@ -242,7 +242,7 @@ export class StreamService {
       handoff = this.handoffBootstrapOnConsumerAttach(bootstrap);
       return media;
     } catch (error) {
-      if (relayStarted) {
+      if (relayStartedExclusively) {
         try {
           await this.stopCompatibilityRelay();
         } catch (stopError) {
@@ -441,7 +441,10 @@ export class StreamService {
     return selection;
   }
 
-  private async ensureCompatibilityRelay(): Promise<number> {
+  private async ensureCompatibilityRelay(): Promise<{
+    port: number;
+    startedExclusively: boolean;
+  }> {
     if (!this.relay) {
       const encoderPool = this.encoderPool ?? getSharedEncoderPool();
       const relayFactory =
@@ -457,6 +460,10 @@ export class StreamService {
         pool: encoderPool,
       });
     }
+    // A shared relay with a listening port is already serving its camera.
+    // A failed request may not tear it down: other consumers use the same
+    // process-wide encoder and TCP endpoint.
+    const alreadyServingConsumers = this.relay.getPort() !== undefined;
     try {
       await this.relay.start();
     } catch (error) {
@@ -474,7 +481,7 @@ export class StreamService {
         `H.264 compatibility relay started without a listening port for ${this.serialNumber}`,
       );
     }
-    return port;
+    return { port, startedExclusively: !alreadyServingConsumers };
   }
 
   private async resolveFfmpegPath(): Promise<string> {

--- a/packages/eufy-security-scrypted/src/services/device/stream-service.ts
+++ b/packages/eufy-security-scrypted/src/services/device/stream-service.ts
@@ -20,7 +20,9 @@ import {
   getSharedH264CompatibilityRelay,
   H264CompatibilityRelay,
   ThermalGovernor,
+  TemperatureReader,
 } from "@caplaz/eufy-stream-server";
+import { readdir, readFile } from "node:fs/promises";
 import { FFmpegUtils } from "../../utils/ffmpeg-utils";
 import { Logger, ILogObj } from "tslog";
 import {
@@ -82,6 +84,11 @@ export interface CompatibilityStreamingConfig {
   recoveryTemperatureC: number;
 }
 
+export interface SharedCompatibilityStreamingDependencies {
+  /** Override the host probe for tests or non-standard deployments. */
+  temperatureReader?: TemperatureReader;
+}
+
 let sharedEncoderPool: CompatibilityEncoderPool | undefined;
 let defaultThermalGovernor: ThermalGovernor | undefined;
 
@@ -92,6 +99,7 @@ let defaultThermalGovernor: ThermalGovernor | undefined;
  */
 export function configureSharedCompatibilityStreaming(
   config: CompatibilityStreamingConfig,
+  dependencies: SharedCompatibilityStreamingDependencies = {},
 ): void {
   validateCompatibilityStreamingConfig(config);
   if (sharedEncoderPool) {
@@ -104,6 +112,8 @@ export function configureSharedCompatibilityStreaming(
   defaultThermalGovernor = new ThermalGovernor({
     criticalTemperatureC: config.criticalTemperatureC,
     recoveryTemperatureC: config.recoveryTemperatureC,
+    temperatureReader:
+      dependencies.temperatureReader ?? readLinuxThermalTemperatureC,
   });
 }
 
@@ -111,8 +121,40 @@ export function getSharedCompatibilityEncoderPool(): CompatibilityEncoderPool {
   return (sharedEncoderPool ??= new CompatibilityEncoderPool());
 }
 
-function getDefaultThermalGovernor(): ThermalGovernor {
-  return (defaultThermalGovernor ??= new ThermalGovernor());
+export function getSharedThermalGovernor(): ThermalGovernor {
+  return (defaultThermalGovernor ??= new ThermalGovernor({
+    temperatureReader: readLinuxThermalTemperatureC,
+  }));
+}
+
+/**
+ * Best-effort Linux temperature probe. Unsupported hosts and inaccessible
+ * sensors fail open by returning undefined, which leaves admission unthrottled.
+ */
+export async function readLinuxThermalTemperatureC(): Promise<
+  number | undefined
+> {
+  if (process.platform !== "linux") return undefined;
+
+  try {
+    const entries = await readdir("/sys/class/thermal", {
+      withFileTypes: true,
+    });
+    for (const entry of entries) {
+      if (!entry.isDirectory() || !entry.name.startsWith("thermal_zone")) {
+        continue;
+      }
+      const raw = Number(
+        (await readFile(`/sys/class/thermal/${entry.name}/temp`, "utf8")).trim(),
+      );
+      if (!Number.isFinite(raw)) continue;
+      return Math.abs(raw) >= 1_000 ? raw / 1_000 : raw;
+    }
+  } catch {
+    // Containers commonly do not expose host thermal zones. This must never
+    // make compatibility streaming unavailable on an otherwise valid host.
+  }
+  return undefined;
 }
 
 function validateCompatibilityStreamingConfig(
@@ -488,7 +530,8 @@ export class StreamService {
       return selection;
     }
 
-    const thermalGovernor = this.thermalGovernor ?? getDefaultThermalGovernor();
+    const thermalGovernor =
+      this.thermalGovernor ?? getSharedThermalGovernor();
     const admitted = await thermalGovernor.checkCompatibilityEncoderAdmission();
     if (admitted) return selection;
     const status = thermalGovernor.getStatus();

--- a/packages/eufy-security-scrypted/src/services/device/types.ts
+++ b/packages/eufy-security-scrypted/src/services/device/types.ts
@@ -8,6 +8,12 @@
 
 import { VideoMetadata } from "@caplaz/eufy-security-client";
 
+export interface MetadataBootstrapWaiter {
+  promise: Promise<VideoMetadata>;
+  release(): void;
+  cancel(): void;
+}
+
 /**
  * StreamServer interface (from @caplaz/eufy-stream-server)
  *
@@ -60,6 +66,18 @@ export interface IStreamServer {
    * Returns null if no stream has been received yet.
    */
   getVideoMetadata(): VideoMetadata | null;
+
+  /** Whether the metadata was observed from the current P2P session. */
+  isMetadataVerifiedForCurrentSession(): boolean;
+
+  /** Keep the upstream live while waiting for fresh session metadata. */
+  acquireMetadataWaiter(timeoutMs?: number): MetadataBootstrapWaiter;
+
+  /** Runs once when a raw or muxed downstream consumer attaches. */
+  onNextConsumerAttached(callback: () => void): () => void;
+
+  /** Audio observed on the current stream, rather than an assumed capability. */
+  getAudioStatus(): "unknown" | "aac" | "none";
 
   /**
    * Get the TCP port the MPEG-TS muxed server is listening on.

--- a/packages/eufy-security-scrypted/tests/unit/eufy-device-ptz.test.ts
+++ b/packages/eufy-security-scrypted/tests/unit/eufy-device-ptz.test.ts
@@ -31,6 +31,7 @@ jest.mock("@scrypted/sdk", () => ({
     log: any = { a: jest.fn(), clearAlert: jest.fn() };
   },
   ScryptedInterface: {
+    VideoCamera: "VideoCamera",
     MotionSensor: "MotionSensor",
     Brightness: "Brightness",
     OnOff: "OnOff",
@@ -61,6 +62,14 @@ jest.mock("@scrypted/sdk", () => ({
 
 // Mock the StreamServer
 jest.mock("@caplaz/eufy-stream-server", () => ({
+  CompatibilityEncoderPool: class {},
+  ThermalGovernor: class {
+    checkCompatibilityEncoderAdmission = jest.fn().mockResolvedValue(true);
+    getStatus = jest
+      .fn()
+      .mockReturnValue({ throttled: false, reason: "unsupported" });
+  },
+  getSharedH264CompatibilityRelay: jest.fn(),
   StreamServer: jest.fn().mockImplementation(() => ({
     start: jest.fn().mockResolvedValue(undefined),
     stop: jest.fn().mockResolvedValue(undefined),
@@ -136,6 +145,21 @@ describe("EufyDevice PTZ Functionality", () => {
   });
 
   describe("PTZ Capabilities Detection", () => {
+    test("reannounces stream options when live codec metadata replaces a hint", () => {
+      const onDeviceEvent = jest.fn();
+      (device as any).onDeviceEvent = onDeviceEvent;
+      const streamServer = (
+        require("@caplaz/eufy-stream-server").StreamServer as jest.Mock
+      ).mock.results.at(-1)?.value;
+      const metadataListener = streamServer.on.mock.calls.find(
+        ([event]: [string]) => event === "metadataReceived",
+      )?.[1];
+
+      metadataListener({ videoCodec: "H265" });
+
+      expect(onDeviceEvent).toHaveBeenCalledWith("VideoCamera", undefined);
+    });
+
     test("should enable PTZ capabilities for pan/tilt capable devices", () => {
       // Mock device type that supports pan/tilt (e.g., Indoor PT Camera)
       const mockProperties = { type: 31 }; // DeviceType that supports pan/tilt

--- a/packages/eufy-security-scrypted/tests/unit/eufy-device-ptz.test.ts
+++ b/packages/eufy-security-scrypted/tests/unit/eufy-device-ptz.test.ts
@@ -145,7 +145,7 @@ describe("EufyDevice PTZ Functionality", () => {
   });
 
   describe("PTZ Capabilities Detection", () => {
-    test("reannounces stream options when live codec metadata replaces a hint", () => {
+    test("persists a changed live codec hint and reannounces stream options", () => {
       const onDeviceEvent = jest.fn();
       (device as any).onDeviceEvent = onDeviceEvent;
       const streamServer = (
@@ -158,6 +158,50 @@ describe("EufyDevice PTZ Functionality", () => {
       metadataListener({ videoCodec: "H265" });
 
       expect(onDeviceEvent).toHaveBeenCalledWith("VideoCamera", undefined);
+      expect((device as any).storage.getItem("lastDetectedVideoCodec")).toBe(
+        "H265",
+      );
+
+      onDeviceEvent.mockClear();
+      metadataListener({ videoCodec: "HEVC" });
+
+      expect(onDeviceEvent).not.toHaveBeenCalled();
+    });
+
+    test("exposes Auto compatibility mode and reannounces options when changed", async () => {
+      await (device as any).propertiesLoaded;
+      (device as any).info = { serialNumber: "TEST123", metadata: {} };
+
+      const setting = (await device.getSettings()).find(
+        (candidate) => candidate.key === "compatibilityMode",
+      );
+
+      expect(setting).toEqual(
+        expect.objectContaining({
+          key: "compatibilityMode",
+          value: "Auto",
+          choices: ["Auto", "Force", "Native"],
+        }),
+      );
+      expect(setting?.description).toContain("CPU");
+      expect(setting?.description).toContain("prebuffer");
+
+      const onDeviceEvent = jest.fn();
+      (device as any).onDeviceEvent = onDeviceEvent;
+      await device.putSetting("compatibilityMode", "Native");
+
+      expect((device as any).storage.getItem("compatibilityMode")).toBe(
+        "Native",
+      );
+      expect(onDeviceEvent).toHaveBeenCalledWith("VideoCamera", undefined);
+    });
+
+    test("rejects an unknown compatibility mode without changing the default", async () => {
+      await expect(
+        device.putSetting("compatibilityMode", "Always"),
+      ).rejects.toThrow("Invalid H.264 compatibility mode");
+
+      expect((device as any).storage.getItem("compatibilityMode")).toBeNull();
     });
 
     test("should enable PTZ capabilities for pan/tilt capable devices", () => {

--- a/packages/eufy-security-scrypted/tests/unit/eufy-provider.test.ts
+++ b/packages/eufy-security-scrypted/tests/unit/eufy-provider.test.ts
@@ -6,12 +6,23 @@ import { EufySecurityProvider } from "../../src/eufy-provider";
 import { DeviceUtils } from "../../src/utils/device-utils";
 import sdk from "@scrypted/sdk";
 import { StartListeningResponse } from "@caplaz/eufy-security-client";
+import { configureSharedCompatibilityStreaming } from "../../src/services/device/stream-service";
+
+jest.mock("../../src/services/device/stream-service", () => ({
+  configureSharedCompatibilityStreaming: jest.fn(),
+  DEFAULT_COMPATIBILITY_STREAMING_CONFIG: {
+    encoderCapacity: 1,
+    criticalTemperatureC: 85,
+    recoveryTemperatureC: 75,
+  },
+}));
 
 jest.mock("@scrypted/sdk", () => ({
   ScryptedDeviceBase: class {
     storage = { getItem: jest.fn().mockReturnValue(null), setItem: jest.fn() };
     console = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
     nativeId = undefined;
+    onDeviceEvent = jest.fn();
   },
   ScryptedInterface: {
     Camera: "Camera",
@@ -66,12 +77,15 @@ jest.mock("@caplaz/eufy-security-client", () => {
     ...actual,
     EufyWebSocketClient: jest.fn().mockImplementation(() => ({
       isConnected: jest.fn().mockReturnValue(false),
+      getState: jest.fn().mockReturnValue({}),
       on: jest.fn(),
       off: jest.fn(),
     })),
     AuthenticationManager: jest.fn().mockImplementation(() => ({
       on: jest.fn(),
       off: jest.fn(),
+      getAuthStatusMessage: jest.fn().mockReturnValue("Ready"),
+      getAuthState: jest.fn().mockReturnValue("none"),
     })),
   };
 });
@@ -80,6 +94,7 @@ jest.mock("../../src/utils/memory-manager", () => ({
   MemoryManager: {
     setMemoryThreshold: jest.fn(),
   },
+  getCurrentMemoryUsageMB: jest.fn().mockReturnValue({ rssMB: 100 }),
 }));
 
 describe("EufySecurityProvider.registerDevicesFromServerState", () => {
@@ -88,6 +103,7 @@ describe("EufySecurityProvider.registerDevicesFromServerState", () => {
   let mockCreateDeviceManifest: jest.Mock;
 
   beforeEach(() => {
+    (configureSharedCompatibilityStreaming as jest.Mock).mockClear();
     mockOnDevicesChanged = sdk.deviceManager.onDevicesChanged as jest.Mock;
     mockOnDevicesChanged.mockClear();
 
@@ -95,6 +111,53 @@ describe("EufySecurityProvider.registerDevicesFromServerState", () => {
     mockCreateDeviceManifest.mockClear();
 
     provider = new EufySecurityProvider("test-provider");
+  });
+
+  it("applies conservative shared compatibility encoder defaults", () => {
+    expect(configureSharedCompatibilityStreaming).toHaveBeenCalledWith({
+      encoderCapacity: 1,
+      criticalTemperatureC: 85,
+      recoveryTemperatureC: 75,
+    });
+  });
+
+  it("shows advanced encoder and thermal settings with conservative defaults", async () => {
+    const settings = await provider.getSettings();
+
+    expect(settings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "compatibilityEncoderCapacity",
+          value: 1,
+        }),
+        expect.objectContaining({
+          key: "compatibilityEncoderCriticalTemperatureC",
+          value: 85,
+        }),
+        expect.objectContaining({
+          key: "compatibilityEncoderRecoveryTemperatureC",
+          value: 75,
+        }),
+      ]),
+    );
+  });
+
+  it("applies a validated capacity update to the shared compatibility pool", async () => {
+    await provider.putSetting("compatibilityEncoderCapacity", 2);
+
+    expect(configureSharedCompatibilityStreaming).toHaveBeenLastCalledWith({
+      encoderCapacity: 2,
+      criticalTemperatureC: 85,
+      recoveryTemperatureC: 75,
+    });
+    expect((provider as any).storage.setItem).toHaveBeenCalledWith(
+      "compatibilityEncoderCapacity",
+      "2",
+    );
+
+    await expect(
+      provider.putSetting("compatibilityEncoderRecoveryTemperatureC", 90),
+    ).rejects.toThrow("recovery temperature must be lower");
   });
 
   it("groups 3 devices across 2 stations into exactly 2 onDevicesChanged calls", async () => {

--- a/packages/eufy-security-scrypted/tests/unit/eufy-provider.test.ts
+++ b/packages/eufy-security-scrypted/tests/unit/eufy-provider.test.ts
@@ -177,6 +177,23 @@ describe("EufySecurityProvider.registerDevicesFromServerState", () => {
     expect(configuration).toHaveBeenCalledTimes(configuredBefore);
   });
 
+  it("rejects nullish encoder updates instead of falling back to stored values", async () => {
+    const storage = (provider as any).storage;
+    storage.getItem.mockImplementation((key: string) =>
+      key === "compatibilityEncoderCapacity" ? "2" : null,
+    );
+    const persistedBefore = storage.setItem.mock.calls.length;
+
+    await expect(
+      provider.putSetting("compatibilityEncoderCapacity", null),
+    ).rejects.toThrow("finite number");
+    await expect(
+      provider.putSetting("compatibilityEncoderCapacity", undefined as any),
+    ).rejects.toThrow("finite number");
+
+    expect(storage.setItem).toHaveBeenCalledTimes(persistedBefore);
+  });
+
   it("groups 3 devices across 2 stations into exactly 2 onDevicesChanged calls", async () => {
     // Two devices on station A, one device on station B
     const manifests = [

--- a/packages/eufy-security-scrypted/tests/unit/eufy-provider.test.ts
+++ b/packages/eufy-security-scrypted/tests/unit/eufy-provider.test.ts
@@ -160,6 +160,23 @@ describe("EufySecurityProvider.registerDevicesFromServerState", () => {
     ).rejects.toThrow("recovery temperature must be lower");
   });
 
+  it("rejects invalid encoder inputs without persisting their raw values", async () => {
+    const setItem = (provider as any).storage.setItem as jest.Mock;
+    const configuration = configureSharedCompatibilityStreaming as jest.Mock;
+    const persistedBefore = setItem.mock.calls.length;
+    const configuredBefore = configuration.mock.calls.length;
+
+    await expect(
+      provider.putSetting("compatibilityEncoderCapacity", "not-a-number"),
+    ).rejects.toThrow("finite number");
+    await expect(
+      provider.putSetting("compatibilityEncoderCriticalTemperatureC", 200),
+    ).rejects.toThrow("between 0 and 125");
+
+    expect(setItem).toHaveBeenCalledTimes(persistedBefore);
+    expect(configuration).toHaveBeenCalledTimes(configuredBefore);
+  });
+
   it("groups 3 devices across 2 stations into exactly 2 onDevicesChanged calls", async () => {
     // Two devices on station A, one device on station B
     const manifests = [

--- a/packages/eufy-security-scrypted/tests/unit/services/stream-selector.test.ts
+++ b/packages/eufy-security-scrypted/tests/unit/services/stream-selector.test.ts
@@ -45,6 +45,26 @@ describe("selectStream", () => {
     });
   });
 
+  it("returns a complete H264-source error for an explicit compatibility stream", () => {
+    expect(
+      select({
+        streamId: "p2p-h264",
+        source: { codec: "H264", verified: true },
+      }),
+    ).toEqual({
+      kind: "error",
+      name: "CompatibilityStreamSelectionError",
+      mode: "Auto",
+      reason: "source-codec-not-h265",
+      source: { codec: "H264", verified: true },
+      availability: "available",
+      message:
+        "Cannot select the compatibility H.264 stream: mode=Auto; " +
+        "reason=source-codec-not-h265; source=H264 (verified); " +
+        "availability=available.",
+    });
+  });
+
   it("does not fall an explicit compatibility stream back to native when admission is unavailable", () => {
     expect(
       select({

--- a/packages/eufy-security-scrypted/tests/unit/services/stream-selector.test.ts
+++ b/packages/eufy-security-scrypted/tests/unit/services/stream-selector.test.ts
@@ -1,0 +1,158 @@
+import {
+  selectStream,
+  StreamSelectionInput,
+} from "../../../src/services/device/stream-selector";
+
+const select = (input: Partial<StreamSelectionInput> = {}) =>
+  selectStream({
+    compatibilityMode: "Auto",
+    source: { codec: "H265", verified: true },
+    ...input,
+  });
+
+describe("selectStream", () => {
+  it("keeps an explicitly requested native stream native", () => {
+    expect(
+      select({
+        streamId: "p2p",
+        compatibilityMode: "Force",
+        source: { codec: undefined, verified: false },
+        availabilityError: "encoder capacity is exhausted",
+      }),
+    ).toEqual({ kind: "stream", streamId: "p2p" });
+  });
+
+  it("honors an explicit compatibility stream only when verified H265 is available", () => {
+    expect(select({ streamId: "p2p-h264" })).toEqual({
+      kind: "stream",
+      streamId: "p2p-h264",
+    });
+  });
+
+  it("does not fall an explicit compatibility stream back to native when the codec is unverified", () => {
+    expect(
+      select({
+        streamId: "p2p-h264",
+        source: { codec: "H265", verified: false },
+      }),
+    ).toMatchObject({
+      kind: "error",
+      name: "CompatibilityStreamSelectionError",
+      mode: "Auto",
+      reason: "source-codec-unverified",
+      source: { codec: "H265", verified: false },
+      availability: "available",
+    });
+  });
+
+  it("does not fall an explicit compatibility stream back to native when admission is unavailable", () => {
+    expect(
+      select({
+        streamId: "p2p-h264",
+        availabilityError: "thermal admission denied",
+      }),
+    ).toMatchObject({
+      kind: "error",
+      name: "CompatibilityStreamSelectionError",
+      mode: "Auto",
+      reason: "compatibility-unavailable",
+      source: { codec: "H265", verified: true },
+      availability: "thermal admission denied",
+    });
+  });
+
+  it("keeps Auto selection native for absent, unknown, and recorder destinations", () => {
+    for (const destination of [
+      undefined,
+      "future-destination",
+      "local-recorder",
+      "remote-recorder",
+    ]) {
+      expect(select({ destination })).toEqual({
+        kind: "stream",
+        streamId: "p2p",
+      });
+    }
+  });
+
+  it("uses compatibility for verified H265 interactive live destinations in Auto mode", () => {
+    for (const destination of ["local", "remote"]) {
+      expect(select({ destination })).toEqual({
+        kind: "stream",
+        streamId: "p2p-h264",
+      });
+    }
+  });
+
+  it("keeps H264 native in Auto mode", () => {
+    expect(
+      select({
+        destination: "local",
+        source: { codec: "H264", verified: true },
+      }),
+    ).toEqual({ kind: "stream", streamId: "p2p" });
+  });
+
+  it("does not guess an unverified interactive source codec in Auto mode", () => {
+    expect(
+      select({
+        destination: "local",
+        source: { codec: "H265", verified: false },
+      }),
+    ).toEqual({ kind: "stream", streamId: "p2p" });
+  });
+
+  it("keeps Native mode native regardless of destination", () => {
+    expect(
+      select({ destination: "local", compatibilityMode: "Native" }),
+    ).toEqual({ kind: "stream", streamId: "p2p" });
+  });
+
+  it("uses compatibility in Force mode for verified H265", () => {
+    expect(select({ compatibilityMode: "Force" })).toEqual({
+      kind: "stream",
+      streamId: "p2p-h264",
+    });
+  });
+
+  it("keeps verified native H264 native in Force mode", () => {
+    expect(
+      select({
+        compatibilityMode: "Force",
+        source: { codec: "H264", verified: true },
+      }),
+    ).toEqual({ kind: "stream", streamId: "p2p" });
+  });
+
+  it("returns a named, actionable error when Force mode has no verified source codec", () => {
+    expect(
+      select({
+        compatibilityMode: "Force",
+        source: { codec: undefined, verified: false },
+      }),
+    ).toMatchObject({
+      kind: "error",
+      name: "CompatibilityStreamSelectionError",
+      mode: "Force",
+      reason: "source-codec-unverified",
+      source: { codec: undefined, verified: false },
+      availability: "available",
+    });
+  });
+
+  it("returns a named, actionable error when Force mode cannot admit compatibility", () => {
+    expect(
+      select({
+        compatibilityMode: "Force",
+        availabilityError: "thermal admission denied",
+      }),
+    ).toMatchObject({
+      kind: "error",
+      name: "CompatibilityStreamSelectionError",
+      mode: "Force",
+      reason: "compatibility-unavailable",
+      source: { codec: "H265", verified: true },
+      availability: "thermal admission denied",
+    });
+  });
+});

--- a/packages/eufy-security-scrypted/tests/unit/services/stream-service.test.ts
+++ b/packages/eufy-security-scrypted/tests/unit/services/stream-service.test.ts
@@ -251,6 +251,33 @@ describe("StreamService", () => {
       expect(result).toBeDefined();
       expect(result.mimeType).toBe("video/h264");
     });
+
+    it("logs requested stream id and destination for the verification gate", async () => {
+      await service.getVideoStream(undefined, {
+        id: "p2p",
+        destination: "local-recorder",
+      } as any);
+      expect(
+        mockLogger.info.mock.calls.some(
+          (c: any[]) =>
+            typeof c[0] === "string" &&
+            c[0].includes("[stream-request]") &&
+            c[0].includes("id=p2p") &&
+            c[0].includes("destination=local-recorder"),
+        ),
+      ).toBe(true);
+    });
+
+    it("logs absent id and destination as <none>", async () => {
+      await service.getVideoStream(undefined, undefined);
+      expect(
+        mockLogger.info.mock.calls.some(
+          (c: any[]) =>
+            typeof c[0] === "string" &&
+            c[0].includes("[stream-request] id=<none> destination=<none>"),
+        ),
+      ).toBe(true);
+    });
   });
 
   describe("stopStream", () => {

--- a/packages/eufy-security-scrypted/tests/unit/services/stream-service.test.ts
+++ b/packages/eufy-security-scrypted/tests/unit/services/stream-service.test.ts
@@ -8,6 +8,14 @@ import { Logger, ILogObj } from "tslog";
 import { VideoQuality } from "@caplaz/eufy-security-client";
 import { MediaObject } from "@scrypted/sdk";
 import sdk from "@scrypted/sdk";
+import { CompatibilityMode } from "../../../src/services/device/stream-selector";
+
+const liveH265Metadata = {
+  videoCodec: "H265" as const,
+  videoWidth: 1920,
+  videoHeight: 1080,
+  videoFPS: 15,
+};
 
 // Mock the SDK
 jest.mock("@scrypted/sdk", () => ({
@@ -43,9 +51,18 @@ describe("StreamService", () => {
       stop: jest.fn().mockResolvedValue(undefined),
       getPort: jest.fn().mockReturnValue(mockPort),
       isRunning: jest.fn().mockReturnValue(false),
-      getVideoMetadata: jest.fn().mockReturnValue(null),
+      getVideoMetadata: jest.fn().mockReturnValue({
+        videoCodec: "H264",
+        videoWidth: 1920,
+        videoHeight: 1080,
+        videoFPS: 15,
+      }),
       getAudioMetadata: jest.fn().mockReturnValue(null),
       getMuxedPort: jest.fn().mockReturnValue(undefined),
+      getAudioStatus: jest.fn().mockReturnValue("aac"),
+      isMetadataVerifiedForCurrentSession: jest.fn().mockReturnValue(true),
+      acquireMetadataWaiter: jest.fn(),
+      onNextConsumerAttached: jest.fn().mockReturnValue(jest.fn()),
       captureSnapshot: jest.fn(),
     } as any;
 
@@ -97,6 +114,41 @@ describe("StreamService", () => {
   });
 
   describe("getVideoStreamOptions", () => {
+    it("does not advertise a stale codec hint as native stream bytes", () => {
+      mockStreamServer.getVideoMetadata.mockReturnValue(liveH265Metadata);
+      mockStreamServer.isMetadataVerifiedForCurrentSession.mockReturnValue(
+        false,
+      );
+      mockStreamServer.getAudioStatus.mockReturnValue("unknown");
+
+      const [native] = service.getVideoStreamOptions(VideoQuality.HIGH);
+
+      expect(native.video).toEqual({ width: 1920, height: 1080 });
+      expect(native.audio).toBeUndefined();
+    });
+
+    it("advertises verified native fMP4 codec and observed audio truthfully", () => {
+      mockStreamServer.getVideoMetadata.mockReturnValue(liveH265Metadata);
+      mockStreamServer.isMetadataVerifiedForCurrentSession.mockReturnValue(
+        true,
+      );
+      mockStreamServer.getAudioStatus.mockReturnValue("none");
+
+      expect(service.getVideoStreamOptions(VideoQuality.HIGH)).toEqual([
+        {
+          id: "p2p",
+          name: "P2P Stream",
+          container: "mp4",
+          video: { codec: "h265", width: 1920, height: 1080 },
+        },
+        {
+          id: "p2p-h264",
+          name: "P2P Stream (H.264 Compatibility)",
+          container: "mp4",
+          video: { codec: "h264", width: 1920, height: 1080 },
+        },
+      ]);
+    });
     it("should return stream options with correct dimensions", () => {
       const options = service.getVideoStreamOptions(VideoQuality.HIGH);
 
@@ -135,6 +187,117 @@ describe("StreamService", () => {
   });
 
   describe("getVideoStream", () => {
+    it("waits for current-session metadata and holds bootstrap until a consumer attaches", async () => {
+      let resolveMetadata!: (metadata: typeof liveH265Metadata) => void;
+      const release = jest.fn();
+      let consumerAttached: (() => void) | undefined;
+      mockStreamServer.isMetadataVerifiedForCurrentSession.mockReturnValue(
+        false,
+      );
+      mockStreamServer.acquireMetadataWaiter.mockReturnValue({
+        promise: new Promise((resolve) => {
+          resolveMetadata = resolve;
+        }),
+        release,
+        cancel: release,
+      });
+      mockStreamServer.onNextConsumerAttached.mockImplementation((callback) => {
+        consumerAttached = callback;
+        return jest.fn();
+      });
+
+      const result = service.getVideoStream(VideoQuality.HIGH, { id: "p2p" });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockStreamServer.acquireMetadataWaiter).toHaveBeenCalledTimes(1);
+      mockStreamServer.isMetadataVerifiedForCurrentSession.mockReturnValue(
+        true,
+      );
+      resolveMetadata(liveH265Metadata);
+      await result;
+
+      expect(release).not.toHaveBeenCalled();
+      consumerAttached?.();
+      expect(release).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps a verified H265 native stream truthful when the consumer requests H264", async () => {
+      mockStreamServer.getVideoMetadata.mockReturnValue(liveH265Metadata);
+      mockStreamServer.isMetadataVerifiedForCurrentSession.mockReturnValue(
+        true,
+      );
+      mockStreamServer.getMuxedPort.mockReturnValue(55555);
+
+      await service.getVideoStream(VideoQuality.HIGH, {
+        id: "p2p",
+        video: { codec: "h264" },
+      } as any);
+
+      expect(sdk.mediaManager.createFFmpegMediaObject).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mediaStreamOptions: expect.objectContaining({
+            video: expect.objectContaining({ codec: "h265" }),
+          }),
+        }),
+      );
+    });
+
+    it("routes an explicit compatibility stream through a shared H264 relay", async () => {
+      const relay = {
+        start: jest.fn().mockResolvedValue(undefined),
+        stop: jest.fn().mockResolvedValue(undefined),
+        getPort: jest.fn().mockReturnValue(45678),
+      };
+      const relayFactory = jest.fn().mockReturnValue(relay);
+      mockStreamServer.getVideoMetadata.mockReturnValue(liveH265Metadata);
+      mockStreamServer.isMetadataVerifiedForCurrentSession.mockReturnValue(
+        true,
+      );
+      mockStreamServer.getMuxedPort.mockReturnValue(55555);
+      service = new StreamService(serialNumber, mockStreamServer, mockLogger, {
+        compatibilityMode: () => "Auto" as CompatibilityMode,
+        relayFactory,
+      });
+
+      await service.getVideoStream(VideoQuality.HIGH, { id: "p2p-h264" });
+
+      expect(relay.start).toHaveBeenCalledTimes(1);
+      expect(sdk.mediaManager.createFFmpegMediaObject).toHaveBeenCalledWith(
+        expect.objectContaining({
+          inputArguments: expect.arrayContaining(["tcp://127.0.0.1:45678"]),
+          mediaStreamOptions: expect.objectContaining({
+            container: "mp4",
+            video: expect.objectContaining({ codec: "h264" }),
+          }),
+        }),
+      );
+    });
+
+    it("reports a thermal admission denial for an explicit compatibility stream", async () => {
+      mockStreamServer.getVideoMetadata.mockReturnValue(liveH265Metadata);
+      mockStreamServer.isMetadataVerifiedForCurrentSession.mockReturnValue(
+        true,
+      );
+      service = new StreamService(serialNumber, mockStreamServer, mockLogger, {
+        thermalGovernor: {
+          checkCompatibilityEncoderAdmission: jest
+            .fn()
+            .mockResolvedValue(false),
+          getStatus: jest.fn().mockReturnValue({
+            throttled: true,
+            reason: "critical-temperature",
+            temperatureC: 92,
+          }),
+        },
+      });
+
+      await expect(
+        service.getVideoStream(VideoQuality.HIGH, { id: "p2p-h264" }),
+      ).rejects.toThrow("compatibility-unavailable");
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("thermal admission denied"),
+      );
+    });
     it("should start stream server if not already started", async () => {
       await service.getVideoStream(VideoQuality.HIGH);
 

--- a/packages/eufy-security-scrypted/tests/unit/services/stream-service.test.ts
+++ b/packages/eufy-security-scrypted/tests/unit/services/stream-service.test.ts
@@ -5,6 +5,7 @@
 import {
   configureSharedCompatibilityStreaming,
   getSharedCompatibilityEncoderPool,
+  getSharedThermalGovernor,
   StreamService,
 } from "../../../src/services/device/stream-service";
 import { CompatibilityEncoderCapacityError } from "@caplaz/eufy-stream-server";
@@ -125,6 +126,34 @@ describe("StreamService", () => {
       consumerKind: "interactive",
     });
     third.release();
+  });
+
+  it("gates compatibility admissions when an injected host temperature is critical", async () => {
+    configureSharedCompatibilityStreaming(
+      {
+        encoderCapacity: 1,
+        criticalTemperatureC: 85,
+        recoveryTemperatureC: 75,
+      },
+      { temperatureReader: async () => 90 },
+    );
+
+    expect(
+      await getSharedThermalGovernor().checkCompatibilityEncoderAdmission(),
+    ).toBe(false);
+    expect(getSharedThermalGovernor().getStatus()).toMatchObject({
+      throttled: true,
+      temperatureC: 90,
+    });
+
+    configureSharedCompatibilityStreaming(
+      {
+        encoderCapacity: 1,
+        criticalTemperatureC: 85,
+        recoveryTemperatureC: 75,
+      },
+      { temperatureReader: async () => undefined },
+    );
   });
 
   describe("getVideoDimensions", () => {

--- a/packages/eufy-security-scrypted/tests/unit/services/stream-service.test.ts
+++ b/packages/eufy-security-scrypted/tests/unit/services/stream-service.test.ts
@@ -281,7 +281,10 @@ describe("StreamService", () => {
           for (const callback of callbacks) callback();
         }),
         stop: jest.fn().mockResolvedValue(undefined),
-        getPort: jest.fn().mockReturnValue(45678),
+        getPort: jest
+          .fn()
+          .mockReturnValueOnce(undefined)
+          .mockReturnValue(45678),
       };
       mockStreamServer.isMetadataVerifiedForCurrentSession.mockReturnValue(
         false,
@@ -317,7 +320,10 @@ describe("StreamService", () => {
       const relay = {
         start: jest.fn().mockResolvedValue(undefined),
         stop: jest.fn().mockResolvedValue(undefined),
-        getPort: jest.fn().mockReturnValue(45678),
+        getPort: jest
+          .fn()
+          .mockReturnValueOnce(undefined)
+          .mockReturnValue(45678),
       };
       mockStreamServer.getVideoMetadata.mockReturnValue(liveH265Metadata);
       mockStreamServer.isMetadataVerifiedForCurrentSession.mockReturnValue(
@@ -335,6 +341,31 @@ describe("StreamService", () => {
       ).rejects.toThrow("media object failed");
 
       expect(relay.stop).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not stop a shared relay already serving another compatibility consumer", async () => {
+      const relay = {
+        start: jest.fn().mockResolvedValue(undefined),
+        stop: jest.fn().mockResolvedValue(undefined),
+        getPort: jest.fn().mockReturnValue(45678),
+      };
+      mockStreamServer.getVideoMetadata.mockReturnValue(liveH265Metadata);
+      mockStreamServer.isMetadataVerifiedForCurrentSession.mockReturnValue(
+        true,
+      );
+      (
+        sdk.mediaManager.createFFmpegMediaObject as jest.Mock
+      ).mockRejectedValueOnce(new Error("second media object failed"));
+      service = new StreamService(serialNumber, mockStreamServer, mockLogger, {
+        relayFactory: jest.fn().mockReturnValue(relay),
+      });
+
+      await expect(
+        service.getVideoStream(VideoQuality.HIGH, { id: "p2p-h264" }),
+      ).rejects.toThrow("second media object failed");
+
+      expect(relay.start).toHaveBeenCalledTimes(1);
+      expect(relay.stop).not.toHaveBeenCalled();
     });
 
     it("reports a thermal admission denial for an explicit compatibility stream", async () => {

--- a/packages/eufy-security-scrypted/tests/unit/services/stream-service.test.ts
+++ b/packages/eufy-security-scrypted/tests/unit/services/stream-service.test.ts
@@ -2,7 +2,12 @@
  * Stream Service Tests
  */
 
-import { StreamService } from "../../../src/services/device/stream-service";
+import {
+  configureSharedCompatibilityStreaming,
+  getSharedCompatibilityEncoderPool,
+  StreamService,
+} from "../../../src/services/device/stream-service";
+import { CompatibilityEncoderCapacityError } from "@caplaz/eufy-stream-server";
 import { IStreamServer } from "../../../src/services/device/types";
 import { Logger, ILogObj } from "tslog";
 import { VideoQuality } from "@caplaz/eufy-security-client";
@@ -79,6 +84,47 @@ describe("StreamService", () => {
 
   afterEach(async () => {
     await service.dispose();
+  });
+
+  it("lowers the shared pool capacity in place without discarding active leases", () => {
+    configureSharedCompatibilityStreaming({
+      encoderCapacity: 2,
+      criticalTemperatureC: 85,
+      recoveryTemperatureC: 75,
+    });
+    const pool = getSharedCompatibilityEncoderPool();
+    const first = pool.acquire({
+      serialNumber: "CAM-1",
+      consumerKind: "interactive",
+    });
+    const second = pool.acquire({
+      serialNumber: "CAM-2",
+      consumerKind: "interactive",
+    });
+
+    configureSharedCompatibilityStreaming({
+      encoderCapacity: 1,
+      criticalTemperatureC: 85,
+      recoveryTemperatureC: 75,
+    });
+
+    expect(getSharedCompatibilityEncoderPool()).toBe(pool);
+    expect(pool.capacity).toBe(1);
+    expect(() =>
+      pool.acquire({ serialNumber: "CAM-3", consumerKind: "interactive" }),
+    ).toThrow(CompatibilityEncoderCapacityError);
+
+    first.release();
+    expect(() =>
+      pool.acquire({ serialNumber: "CAM-3", consumerKind: "interactive" }),
+    ).toThrow(CompatibilityEncoderCapacityError);
+
+    second.release();
+    const third = pool.acquire({
+      serialNumber: "CAM-3",
+      consumerKind: "interactive",
+    });
+    third.release();
   });
 
   describe("getVideoDimensions", () => {

--- a/packages/eufy-security-scrypted/tests/unit/services/stream-service.test.ts
+++ b/packages/eufy-security-scrypted/tests/unit/services/stream-service.test.ts
@@ -256,6 +256,7 @@ describe("StreamService", () => {
       await service.getVideoStream(undefined, {
         id: "p2p",
         destination: "local-recorder",
+        tool: "ffmpeg",
       } as any);
       expect(
         mockLogger.info.mock.calls.some(
@@ -263,7 +264,8 @@ describe("StreamService", () => {
             typeof c[0] === "string" &&
             c[0].includes("[stream-request]") &&
             c[0].includes("id=p2p") &&
-            c[0].includes("destination=local-recorder"),
+            c[0].includes("destination=local-recorder") &&
+            c[0].includes("tool=ffmpeg"),
         ),
       ).toBe(true);
     });
@@ -274,9 +276,29 @@ describe("StreamService", () => {
         mockLogger.info.mock.calls.some(
           (c: any[]) =>
             typeof c[0] === "string" &&
-            c[0].includes("[stream-request] id=<none> destination=<none>"),
+            c[0].includes(
+              "[stream-request] id=<none> destination=<none> tool=<none>",
+            ),
         ),
       ).toBe(true);
+    });
+
+    it("escapes CR/LF in requested stream fields to keep the log entry on one line", async () => {
+      await service.getVideoStream(undefined, {
+        id: "p2p\nspoofed",
+        destination: "local\r\nrecorder",
+        tool: "ffmpeg\rtool",
+      } as any);
+
+      const streamRequest = mockLogger.info.mock.calls.find(
+        (c: any[]) =>
+          typeof c[0] === "string" && c[0].includes("[stream-request]"),
+      );
+
+      expect(streamRequest?.[0]).toBe(
+        "[stream-request] id=p2p\\nspoofed destination=local\\r\\nrecorder tool=ffmpeg\\rtool",
+      );
+      expect(streamRequest?.[0]).not.toMatch(/[\r\n]/);
     });
   });
 

--- a/packages/eufy-security-scrypted/tests/unit/services/stream-service.test.ts
+++ b/packages/eufy-security-scrypted/tests/unit/services/stream-service.test.ts
@@ -273,6 +273,70 @@ describe("StreamService", () => {
       );
     });
 
+    it("registers bootstrap handoff before the relay attaches its muxed source", async () => {
+      const release = jest.fn();
+      const callbacks = new Set<() => void>();
+      const relay = {
+        start: jest.fn().mockImplementation(async () => {
+          for (const callback of callbacks) callback();
+        }),
+        stop: jest.fn().mockResolvedValue(undefined),
+        getPort: jest.fn().mockReturnValue(45678),
+      };
+      mockStreamServer.isMetadataVerifiedForCurrentSession.mockReturnValue(
+        false,
+      );
+      mockStreamServer.acquireMetadataWaiter.mockReturnValue({
+        promise: Promise.resolve(liveH265Metadata),
+        release,
+        cancel: release,
+      });
+      mockStreamServer.onNextConsumerAttached.mockImplementation((callback) => {
+        callbacks.add(callback);
+        return () => callbacks.delete(callback);
+      });
+      mockStreamServer.getMuxedPort.mockReturnValue(55555);
+      service = new StreamService(serialNumber, mockStreamServer, mockLogger, {
+        relayFactory: jest.fn().mockReturnValue(relay),
+      });
+
+      await Promise.resolve();
+      const stream = service.getVideoStream(VideoQuality.HIGH, {
+        id: "p2p-h264",
+      });
+      await Promise.resolve();
+      mockStreamServer.isMetadataVerifiedForCurrentSession.mockReturnValue(
+        true,
+      );
+      await stream;
+
+      expect(release).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops a started relay when compatibility media-object creation fails", async () => {
+      const relay = {
+        start: jest.fn().mockResolvedValue(undefined),
+        stop: jest.fn().mockResolvedValue(undefined),
+        getPort: jest.fn().mockReturnValue(45678),
+      };
+      mockStreamServer.getVideoMetadata.mockReturnValue(liveH265Metadata);
+      mockStreamServer.isMetadataVerifiedForCurrentSession.mockReturnValue(
+        true,
+      );
+      (
+        sdk.mediaManager.createFFmpegMediaObject as jest.Mock
+      ).mockRejectedValueOnce(new Error("media object failed"));
+      service = new StreamService(serialNumber, mockStreamServer, mockLogger, {
+        relayFactory: jest.fn().mockReturnValue(relay),
+      });
+
+      await expect(
+        service.getVideoStream(VideoQuality.HIGH, { id: "p2p-h264" }),
+      ).rejects.toThrow("media object failed");
+
+      expect(relay.stop).toHaveBeenCalledTimes(1);
+    });
+
     it("reports a thermal admission denial for an explicit compatibility stream", async () => {
       mockStreamServer.getVideoMetadata.mockReturnValue(liveH265Metadata);
       mockStreamServer.isMetadataVerifiedForCurrentSession.mockReturnValue(

--- a/packages/eufy-stream-server/src/compatibility-encoder-pool.ts
+++ b/packages/eufy-stream-server/src/compatibility-encoder-pool.ts
@@ -116,7 +116,13 @@ export class CompatibilityEncoderPool {
           ? this.findOldestPreemptibleSlot()
           : undefined;
       if (victim) {
-        this.preempt(victim, now);
+        const slot = this.createSlot(request, now);
+        // Attach the requesting interactive lease before notifying the victim.
+        // A synchronous callback can now reenter acquire, but it sees this
+        // protected slot and cannot take the capacity we just made available.
+        const lease = this.addLease(slot, request);
+        this.preempt(victim, now, slot);
+        return lease;
       }
     }
 
@@ -128,13 +134,7 @@ export class CompatibilityEncoderPool {
       );
     }
 
-    const slot: EncoderSlot = {
-      serialNumber: request.serialNumber,
-      name: request.name,
-      acquiredAt: now,
-      sequence: this.nextSequence++,
-      leases: new Map(),
-    };
+    const slot = this.createSlot(request, now);
     this.slots.set(slot.serialNumber, slot);
     return this.addLease(slot, request);
   }
@@ -190,9 +190,27 @@ export class CompatibilityEncoderPool {
       )[0];
   }
 
-  private preempt(slot: EncoderSlot, now: number): void {
+  private createSlot(
+    request: CompatibilityEncoderAcquireRequest,
+    acquiredAt: number,
+  ): EncoderSlot {
+    return {
+      serialNumber: request.serialNumber,
+      name: request.name,
+      acquiredAt,
+      sequence: this.nextSequence++,
+      leases: new Map(),
+    };
+  }
+
+  private preempt(
+    slot: EncoderSlot,
+    now: number,
+    replacement: EncoderSlot,
+  ): void {
     this.slots.delete(slot.serialNumber);
     this.cooldownUntil.set(slot.serialNumber, now + this.preemptionCooldownMs);
+    this.slots.set(replacement.serialNumber, replacement);
 
     for (const lease of slot.leases.values()) {
       try {

--- a/packages/eufy-stream-server/src/compatibility-encoder-pool.ts
+++ b/packages/eufy-stream-server/src/compatibility-encoder-pool.ts
@@ -1,0 +1,236 @@
+import { cpus } from "os";
+
+export type CompatibilityEncoderConsumerKind = "prebuffer" | "interactive";
+
+export interface CompatibilityEncoderAcquireRequest {
+  serialNumber: string;
+  name?: string;
+  consumerKind: CompatibilityEncoderConsumerKind;
+  onPreempt?: () => void | Promise<void>;
+}
+
+export interface CompatibilityEncoderPoolOptions {
+  capacity?: number;
+  cpuCount?: number;
+  preemptionCooldownMs?: number;
+  now?: () => number;
+}
+
+export interface CompatibilityEncoderHolder {
+  serialNumber: string;
+  name?: string;
+  consumers: Record<CompatibilityEncoderConsumerKind, number>;
+  totalConsumers: number;
+  preemptible: boolean;
+  acquiredAt: number;
+}
+
+export interface CompatibilityEncoderLease {
+  readonly serialNumber: string;
+  readonly consumerKind: CompatibilityEncoderConsumerKind;
+  release(): void;
+}
+
+interface LeaseRecord {
+  consumerKind: CompatibilityEncoderConsumerKind;
+  onPreempt?: () => void | Promise<void>;
+}
+
+interface EncoderSlot {
+  serialNumber: string;
+  name?: string;
+  acquiredAt: number;
+  sequence: number;
+  leases: Map<number, LeaseRecord>;
+}
+
+const DEFAULT_PREEMPTION_COOLDOWN_MS = 30_000;
+
+/**
+ * Signals that the process-wide H.264 compatibility encoder limit has been
+ * reached. The holder snapshot identifies sessions which can be released.
+ */
+export class CompatibilityEncoderCapacityError extends Error {
+  public readonly code = "COMPATIBILITY_ENCODER_CAPACITY";
+
+  public constructor(
+    public readonly requestedSerialNumber: string,
+    public readonly holders: CompatibilityEncoderHolder[],
+    public readonly capacity: number,
+  ) {
+    super(
+      `Compatibility encoder capacity (${capacity}) is exhausted for camera ${requestedSerialNumber}. ` +
+        "Release an active compatibility stream or wait for a prebuffer slot to become available.",
+    );
+    this.name = "CompatibilityEncoderCapacityError";
+  }
+}
+
+/**
+ * Process-wide capacity manager for H.265-to-H.264 compatibility encoders.
+ * A camera owns at most one encoder slot, even when several consumers share it.
+ */
+export class CompatibilityEncoderPool {
+  public readonly capacity: number;
+
+  private readonly slots = new Map<string, EncoderSlot>();
+  private readonly cooldownUntil = new Map<string, number>();
+  private readonly now: () => number;
+  private readonly preemptionCooldownMs: number;
+  private nextLeaseId = 0;
+  private nextSequence = 0;
+
+  public constructor(options: CompatibilityEncoderPoolOptions = {}) {
+    const cpuCount = options.cpuCount ?? cpus().length;
+    this.capacity = options.capacity ?? defaultCapacity(cpuCount);
+    if (!Number.isInteger(this.capacity) || this.capacity < 1) {
+      throw new RangeError("Compatibility encoder pool capacity must be a positive integer");
+    }
+
+    this.preemptionCooldownMs =
+      options.preemptionCooldownMs ?? DEFAULT_PREEMPTION_COOLDOWN_MS;
+    if (this.preemptionCooldownMs < 0) {
+      throw new RangeError("Compatibility encoder pool cooldown must not be negative");
+    }
+    this.now = options.now ?? Date.now;
+  }
+
+  public acquire(request: CompatibilityEncoderAcquireRequest): CompatibilityEncoderLease {
+    const existing = this.slots.get(request.serialNumber);
+    if (existing) {
+      if (request.name && !existing.name) {
+        existing.name = request.name;
+      }
+      return this.addLease(existing, request);
+    }
+
+    const now = this.now();
+    const inCooldown = (this.cooldownUntil.get(request.serialNumber) ?? 0) > now;
+    if (!inCooldown) {
+      this.cooldownUntil.delete(request.serialNumber);
+    }
+
+    if (this.slots.size >= this.capacity) {
+      const victim =
+        request.consumerKind === "interactive" && !inCooldown
+          ? this.findOldestPreemptibleSlot()
+          : undefined;
+      if (victim) {
+        this.preempt(victim, now);
+      }
+    }
+
+    if (this.slots.size >= this.capacity) {
+      throw new CompatibilityEncoderCapacityError(
+        request.serialNumber,
+        this.getDiagnostics(),
+        this.capacity,
+      );
+    }
+
+    const slot: EncoderSlot = {
+      serialNumber: request.serialNumber,
+      name: request.name,
+      acquiredAt: now,
+      sequence: this.nextSequence++,
+      leases: new Map(),
+    };
+    this.slots.set(slot.serialNumber, slot);
+    return this.addLease(slot, request);
+  }
+
+  public get diagnostics(): CompatibilityEncoderHolder[] {
+    return this.getDiagnostics();
+  }
+
+  public getDiagnostics(): CompatibilityEncoderHolder[] {
+    return [...this.slots.values()].map((slot) => this.toHolder(slot));
+  }
+
+  private addLease(
+    slot: EncoderSlot,
+    request: CompatibilityEncoderAcquireRequest,
+  ): CompatibilityEncoderLease {
+    const leaseId = this.nextLeaseId++;
+    slot.leases.set(leaseId, {
+      consumerKind: request.consumerKind,
+      onPreempt: request.onPreempt,
+    });
+    let released = false;
+
+    return {
+      serialNumber: slot.serialNumber,
+      consumerKind: request.consumerKind,
+      release: () => {
+        if (released) {
+          return;
+        }
+        released = true;
+        this.release(slot, leaseId);
+      },
+    };
+  }
+
+  private release(slot: EncoderSlot, leaseId: number): void {
+    if (this.slots.get(slot.serialNumber) !== slot) {
+      return;
+    }
+    slot.leases.delete(leaseId);
+    if (slot.leases.size === 0) {
+      this.slots.delete(slot.serialNumber);
+    }
+  }
+
+  private findOldestPreemptibleSlot(): EncoderSlot | undefined {
+    return [...this.slots.values()]
+      .filter((slot) => this.isPreemptible(slot))
+      .sort(
+        (left, right) =>
+          left.acquiredAt - right.acquiredAt || left.sequence - right.sequence,
+      )[0];
+  }
+
+  private preempt(slot: EncoderSlot, now: number): void {
+    this.slots.delete(slot.serialNumber);
+    this.cooldownUntil.set(slot.serialNumber, now + this.preemptionCooldownMs);
+
+    for (const lease of slot.leases.values()) {
+      try {
+        const result = lease.onPreempt?.();
+        if (result) {
+          void result.catch(() => undefined);
+        }
+      } catch {
+        // An eviction callback is cleanup work; it must not prevent capacity release.
+      }
+    }
+    slot.leases.clear();
+  }
+
+  private isPreemptible(slot: EncoderSlot): boolean {
+    return slot.leases.size > 0 &&
+      [...slot.leases.values()].every((lease) => lease.consumerKind === "prebuffer");
+  }
+
+  private toHolder(slot: EncoderSlot): CompatibilityEncoderHolder {
+    const consumers: Record<CompatibilityEncoderConsumerKind, number> = {
+      prebuffer: 0,
+      interactive: 0,
+    };
+    for (const lease of slot.leases.values()) {
+      consumers[lease.consumerKind]++;
+    }
+    return {
+      serialNumber: slot.serialNumber,
+      name: slot.name,
+      consumers,
+      totalConsumers: slot.leases.size,
+      preemptible: this.isPreemptible(slot),
+      acquiredAt: slot.acquiredAt,
+    };
+  }
+}
+
+function defaultCapacity(cpuCount: number): number {
+  return Math.max(1, Math.min(4, Math.floor(cpuCount / 2)));
+}

--- a/packages/eufy-stream-server/src/compatibility-encoder-pool.ts
+++ b/packages/eufy-stream-server/src/compatibility-encoder-pool.ts
@@ -71,7 +71,7 @@ export class CompatibilityEncoderCapacityError extends Error {
  * A camera owns at most one encoder slot, even when several consumers share it.
  */
 export class CompatibilityEncoderPool {
-  public readonly capacity: number;
+  private _capacity: number;
 
   private readonly slots = new Map<string, EncoderSlot>();
   private readonly cooldownUntil = new Map<string, number>();
@@ -82,10 +82,8 @@ export class CompatibilityEncoderPool {
 
   public constructor(options: CompatibilityEncoderPoolOptions = {}) {
     const cpuCount = options.cpuCount ?? cpus().length;
-    this.capacity = options.capacity ?? defaultCapacity(cpuCount);
-    if (!Number.isInteger(this.capacity) || this.capacity < 1) {
-      throw new RangeError("Compatibility encoder pool capacity must be a positive integer");
-    }
+    this._capacity = options.capacity ?? defaultCapacity(cpuCount);
+    this.assertCapacity(this._capacity);
 
     this.preemptionCooldownMs =
       options.preemptionCooldownMs ?? DEFAULT_PREEMPTION_COOLDOWN_MS;
@@ -93,6 +91,20 @@ export class CompatibilityEncoderPool {
       throw new RangeError("Compatibility encoder pool cooldown must not be negative");
     }
     this.now = options.now ?? Date.now;
+  }
+
+  public get capacity(): number {
+    return this._capacity;
+  }
+
+  /**
+   * Update the admission limit without dropping existing leases. Lowering the
+   * limit below the active holder count blocks all new admissions until enough
+   * existing relays release themselves.
+   */
+  public setCapacity(capacity: number): void {
+    this.assertCapacity(capacity);
+    this._capacity = capacity;
   }
 
   public acquire(request: CompatibilityEncoderAcquireRequest): CompatibilityEncoderLease {
@@ -108,6 +120,17 @@ export class CompatibilityEncoderPool {
     const inCooldown = (this.cooldownUntil.get(request.serialNumber) ?? 0) > now;
     if (!inCooldown) {
       this.cooldownUntil.delete(request.serialNumber);
+    }
+
+    // Never replace a holder while the pool is already over a newly lowered
+    // capacity. Existing relays are allowed to drain, but new callers cannot
+    // use preemption to slip into the over-capacity set.
+    if (this.slots.size > this.capacity) {
+      throw new CompatibilityEncoderCapacityError(
+        request.serialNumber,
+        this.getDiagnostics(),
+        this.capacity,
+      );
     }
 
     if (this.slots.size >= this.capacity) {
@@ -246,6 +269,14 @@ export class CompatibilityEncoderPool {
       preemptible: this.isPreemptible(slot),
       acquiredAt: slot.acquiredAt,
     };
+  }
+
+  private assertCapacity(capacity: number): void {
+    if (!Number.isInteger(capacity) || capacity < 1) {
+      throw new RangeError(
+        "Compatibility encoder pool capacity must be a positive integer",
+      );
+    }
   }
 }
 

--- a/packages/eufy-stream-server/src/fmp4-box-stream.ts
+++ b/packages/eufy-stream-server/src/fmp4-box-stream.ts
@@ -14,6 +14,8 @@ interface TfhdInfo {
 const BOX_HEADER_SIZE = 8;
 const EXTENDED_BOX_HEADER_SIZE = 16;
 const SAMPLE_IS_NON_SYNC = 0x00010000;
+const MAX_BOX_SIZE = 16 * 1024 * 1024;
+const MAX_BUFFER_SIZE = MAX_BOX_SIZE;
 
 /**
  * Parse a complete sequence of ISO-BMFF boxes. Incomplete or malformed input
@@ -43,7 +45,7 @@ function parseBoxes(data: Buffer): IsoBox[] | undefined {
       return undefined;
     }
 
-    if (size > data.length - offset) return undefined;
+    if (size > MAX_BOX_SIZE || size > data.length - offset) return undefined;
 
     boxes.push({
       type: data.toString("ascii", offset + 4, offset + 8),
@@ -138,19 +140,31 @@ function readTrunSync(trun: IsoBox, defaultSampleFlags?: number): boolean | unde
   };
 
   if (flags & 0x000001 && !skip(4)) return undefined;
+  let firstSampleFlags: number | undefined;
   if (flags & 0x000004) {
     if (offset + 4 > trun.data.length) return undefined;
-    return sampleFlagsAreSync(trun.data.readUInt32BE(offset));
+    firstSampleFlags = trun.data.readUInt32BE(offset);
+    offset += 4;
   }
-  if (flags & 0x000100 && !skip(4)) return undefined;
-  if (flags & 0x000200 && !skip(4)) return undefined;
-  if (flags & 0x000400) {
-    if (offset + 4 > trun.data.length) return undefined;
-    return sampleFlagsAreSync(trun.data.readUInt32BE(offset));
+
+  const sampleDurationSize = flags & 0x000100 ? 4 : 0;
+  const sampleSizeSize = flags & 0x000200 ? 4 : 0;
+  const sampleFlagsSize = flags & 0x000400 ? 4 : 0;
+  const compositionOffsetSize = flags & 0x000800 ? 4 : 0;
+  const sampleRecordSize =
+    sampleDurationSize + sampleSizeSize + sampleFlagsSize + compositionOffsetSize;
+  if (
+    sampleRecordSize > 0 &&
+    sampleCount > Math.floor((trun.data.length - offset) / sampleRecordSize)
+  ) {
+    return undefined;
   }
-  return defaultSampleFlags === undefined
-    ? undefined
-    : sampleFlagsAreSync(defaultSampleFlags);
+
+  const perSampleFlags = sampleFlagsSize
+    ? trun.data.readUInt32BE(offset + sampleDurationSize + sampleSizeSize)
+    : undefined;
+  const sampleFlags = firstSampleFlags ?? perSampleFlags ?? defaultSampleFlags;
+  return sampleFlags === undefined ? undefined : sampleFlagsAreSync(sampleFlags);
 }
 
 /**
@@ -194,6 +208,13 @@ export class Fmp4BoxStream extends EventEmitter {
   private fragmentPrefix: Buffer[] = [];
 
   write(chunk: Uint8Array): void {
+    if (
+      chunk.length > MAX_BUFFER_SIZE ||
+      this.pending.length > MAX_BUFFER_SIZE - chunk.length
+    ) {
+      this.failInvalidSize();
+      return;
+    }
     this.pending = Buffer.concat([this.pending, Buffer.from(chunk)]);
 
     while (this.pending.length >= BOX_HEADER_SIZE) {
@@ -242,6 +263,7 @@ export class Fmp4BoxStream extends EventEmitter {
     } else if (size < BOX_HEADER_SIZE) {
       return null;
     }
+    if (size > MAX_BOX_SIZE) return null;
     return { size };
   }
 

--- a/packages/eufy-stream-server/src/fmp4-box-stream.ts
+++ b/packages/eufy-stream-server/src/fmp4-box-stream.ts
@@ -1,0 +1,297 @@
+import { EventEmitter } from "events";
+
+interface IsoBox {
+  type: string;
+  raw: Buffer;
+  data: Buffer;
+}
+
+interface TfhdInfo {
+  trackId: number;
+  defaultSampleFlags?: number;
+}
+
+const BOX_HEADER_SIZE = 8;
+const EXTENDED_BOX_HEADER_SIZE = 16;
+const SAMPLE_IS_NON_SYNC = 0x00010000;
+
+/**
+ * Parse a complete sequence of ISO-BMFF boxes. Incomplete or malformed input
+ * is deliberately rejected rather than being interpreted with unchecked reads.
+ */
+function parseBoxes(data: Buffer): IsoBox[] | undefined {
+  const boxes: IsoBox[] = [];
+  let offset = 0;
+
+  while (offset < data.length) {
+    if (data.length - offset < BOX_HEADER_SIZE) return undefined;
+
+    let size = data.readUInt32BE(offset);
+    let headerSize = BOX_HEADER_SIZE;
+    if (size === 1) {
+      if (data.length - offset < EXTENDED_BOX_HEADER_SIZE) return undefined;
+      const extendedSize = data.readBigUInt64BE(offset + BOX_HEADER_SIZE);
+      if (
+        extendedSize < BigInt(EXTENDED_BOX_HEADER_SIZE) ||
+        extendedSize > BigInt(Number.MAX_SAFE_INTEGER)
+      ) {
+        return undefined;
+      }
+      size = Number(extendedSize);
+      headerSize = EXTENDED_BOX_HEADER_SIZE;
+    } else if (size < BOX_HEADER_SIZE) {
+      return undefined;
+    }
+
+    if (size > data.length - offset) return undefined;
+
+    boxes.push({
+      type: data.toString("ascii", offset + 4, offset + 8),
+      raw: data.subarray(offset, offset + size),
+      data: data.subarray(offset + headerSize, offset + size),
+    });
+    offset += size;
+  }
+
+  return boxes;
+}
+
+function boxChildren(box: IsoBox, type: string): IsoBox[] | undefined {
+  const children = parseBoxes(box.data);
+  return children?.filter((child) => child.type === type);
+}
+
+function readTkhdTrackId(tkhd: IsoBox): number | undefined {
+  if (tkhd.data.length < 1) return undefined;
+  const trackIdOffset = tkhd.data[0] === 1 ? 20 : tkhd.data[0] === 0 ? 12 : undefined;
+  if (trackIdOffset === undefined || tkhd.data.length < trackIdOffset + 4) {
+    return undefined;
+  }
+  return tkhd.data.readUInt32BE(trackIdOffset);
+}
+
+function hdlrIsVideo(hdlr: IsoBox): boolean {
+  return hdlr.data.length >= 12 && hdlr.data.toString("ascii", 8, 12) === "vide";
+}
+
+/** Finds the track ID belonging to the first video track in an init segment. */
+export function findVideoTrackId(init: Buffer): number | undefined {
+  const topLevel = parseBoxes(init);
+  const moov = topLevel?.find((box) => box.type === "moov");
+  if (!moov) return undefined;
+
+  const tracks = boxChildren(moov, "trak");
+  if (!tracks) return undefined;
+
+  for (const track of tracks) {
+    const tkhd = boxChildren(track, "tkhd")?.[0];
+    const mdia = boxChildren(track, "mdia")?.[0];
+    const hdlr = mdia && boxChildren(mdia, "hdlr")?.[0];
+    if (!tkhd || !hdlr || !hdlrIsVideo(hdlr)) continue;
+
+    const trackId = readTkhdTrackId(tkhd);
+    if (trackId !== undefined) return trackId;
+  }
+
+  return undefined;
+}
+
+function readTfhd(tfhd: IsoBox): TfhdInfo | undefined {
+  if (tfhd.data.length < 8) return undefined;
+
+  const flags = tfhd.data.readUInt32BE(0) & 0x00ffffff;
+  let offset = 8;
+  const skip = (length: number): boolean => {
+    if (offset + length > tfhd.data.length) return false;
+    offset += length;
+    return true;
+  };
+
+  if (flags & 0x000001 && !skip(8)) return undefined;
+  if (flags & 0x000002 && !skip(4)) return undefined;
+  if (flags & 0x000008 && !skip(4)) return undefined;
+  if (flags & 0x000010 && !skip(4)) return undefined;
+
+  const info: TfhdInfo = { trackId: tfhd.data.readUInt32BE(4) };
+  if (flags & 0x000020) {
+    if (offset + 4 > tfhd.data.length) return undefined;
+    info.defaultSampleFlags = tfhd.data.readUInt32BE(offset);
+  }
+  return info;
+}
+
+function sampleFlagsAreSync(flags: number): boolean {
+  return (flags & SAMPLE_IS_NON_SYNC) === 0;
+}
+
+function readTrunSync(trun: IsoBox, defaultSampleFlags?: number): boolean | undefined {
+  if (trun.data.length < 8) return undefined;
+
+  const flags = trun.data.readUInt32BE(0) & 0x00ffffff;
+  const sampleCount = trun.data.readUInt32BE(4);
+  if (sampleCount === 0) return undefined;
+  let offset = 8;
+  const skip = (length: number): boolean => {
+    if (offset + length > trun.data.length) return false;
+    offset += length;
+    return true;
+  };
+
+  if (flags & 0x000001 && !skip(4)) return undefined;
+  if (flags & 0x000004) {
+    if (offset + 4 > trun.data.length) return undefined;
+    return sampleFlagsAreSync(trun.data.readUInt32BE(offset));
+  }
+  if (flags & 0x000100 && !skip(4)) return undefined;
+  if (flags & 0x000200 && !skip(4)) return undefined;
+  if (flags & 0x000400) {
+    if (offset + 4 > trun.data.length) return undefined;
+    return sampleFlagsAreSync(trun.data.readUInt32BE(offset));
+  }
+  return defaultSampleFlags === undefined
+    ? undefined
+    : sampleFlagsAreSync(defaultSampleFlags);
+}
+
+/**
+ * Determines whether the first sample of the requested video track is sync.
+ * Missing fields and malformed boxes are treated as unknown (false).
+ */
+export function moofFirstSampleIsSync(moofData: Buffer, videoTrackId: number): boolean {
+  const topLevel = parseBoxes(moofData);
+  const moof = topLevel?.find((box) => box.type === "moof");
+  if (!moof) return false;
+
+  const trafs = boxChildren(moof, "traf");
+  if (!trafs) return false;
+  for (const traf of trafs) {
+    const children = parseBoxes(traf.data);
+    const tfhdBox = children?.find((box) => box.type === "tfhd");
+    if (!tfhdBox) continue;
+
+    const tfhd = readTfhd(tfhdBox);
+    if (!tfhd || tfhd.trackId !== videoTrackId) continue;
+
+    for (const trun of children.filter((box) => box.type === "trun")) {
+      const isSync = readTrunSync(trun, tfhd.defaultSampleFlags);
+      if (isSync !== undefined) return isSync;
+    }
+    return false;
+  }
+
+  return false;
+}
+
+/** Incrementally groups fMP4 boxes into init segments and media fragments. */
+export class Fmp4BoxStream extends EventEmitter {
+  private pending = Buffer.alloc(0);
+  private ftyp?: Buffer;
+  private moov?: Buffer;
+  private initEmitted = false;
+  private styp?: Buffer;
+  private sidx?: Buffer;
+  private moof?: Buffer;
+  private fragmentPrefix: Buffer[] = [];
+
+  write(chunk: Uint8Array): void {
+    this.pending = Buffer.concat([this.pending, Buffer.from(chunk)]);
+
+    while (this.pending.length >= BOX_HEADER_SIZE) {
+      const parsedHeader = this.readPendingHeader();
+      if (parsedHeader === undefined) return;
+      if (parsedHeader === null) {
+        this.failInvalidSize();
+        return;
+      }
+      const { size } = parsedHeader;
+      if (this.pending.length < size) return;
+
+      const box = this.pending.subarray(0, size);
+      this.pending = this.pending.subarray(size);
+      this.handleBox(box);
+    }
+  }
+
+  push(chunk: Uint8Array): void {
+    this.write(chunk);
+  }
+
+  reset(): void {
+    this.pending = Buffer.alloc(0);
+    this.ftyp = undefined;
+    this.moov = undefined;
+    this.initEmitted = false;
+    this.styp = undefined;
+    this.sidx = undefined;
+    this.moof = undefined;
+    this.fragmentPrefix = [];
+  }
+
+  private readPendingHeader(): { size: number } | null | undefined {
+    let size = this.pending.readUInt32BE(0);
+    if (size === 1) {
+      if (this.pending.length < EXTENDED_BOX_HEADER_SIZE) return undefined;
+      const extendedSize = this.pending.readBigUInt64BE(BOX_HEADER_SIZE);
+      if (
+        extendedSize < BigInt(EXTENDED_BOX_HEADER_SIZE) ||
+        extendedSize > BigInt(Number.MAX_SAFE_INTEGER)
+      ) {
+        return null;
+      }
+      size = Number(extendedSize);
+    } else if (size < BOX_HEADER_SIZE) {
+      return null;
+    }
+    return { size };
+  }
+
+  private handleBox(box: Buffer): void {
+    const type = box.toString("ascii", 4, 8);
+    switch (type) {
+      case "ftyp":
+        this.ftyp = box;
+        this.emitInit();
+        break;
+      case "moov":
+        this.moov = box;
+        this.emitInit();
+        break;
+      case "styp":
+        this.styp = box;
+        break;
+      case "sidx":
+        this.sidx = box;
+        break;
+      case "moof":
+        this.moof = box;
+        this.fragmentPrefix = [this.styp, this.sidx].filter(
+          (part): part is Buffer => part !== undefined,
+        );
+        this.styp = undefined;
+        this.sidx = undefined;
+        break;
+      case "mdat":
+        if (this.moof) {
+          this.emit("fragment", Buffer.concat([...this.fragmentPrefix, this.moof, box]));
+          this.moof = undefined;
+          this.fragmentPrefix = [];
+        }
+        break;
+      default:
+        // Free, skip, and vendor-specific boxes are intentionally not relayed.
+        break;
+    }
+  }
+
+  private emitInit(): void {
+    if (!this.initEmitted && this.ftyp && this.moov) {
+      this.emit("init", Buffer.concat([this.ftyp, this.moov]));
+      this.initEmitted = true;
+    }
+  }
+
+  private failInvalidSize(): void {
+    this.reset();
+    this.emit("error", new Error("Invalid ISO-BMFF box size"));
+  }
+}

--- a/packages/eufy-stream-server/src/fmp4-box-stream.ts
+++ b/packages/eufy-stream-server/src/fmp4-box-stream.ts
@@ -198,7 +198,11 @@ export function moofFirstSampleIsSync(moofData: Buffer, videoTrackId: number): b
 
 /** Incrementally groups fMP4 boxes into init segments and media fragments. */
 export class Fmp4BoxStream extends EventEmitter {
-  private pending = Buffer.alloc(0);
+  private header = Buffer.alloc(EXTENDED_BOX_HEADER_SIZE);
+  private headerLength = 0;
+  private currentBox?: Buffer;
+  private currentBoxLength = 0;
+  private expectedBoxSize?: number;
   private ftyp?: Buffer;
   private moov?: Buffer;
   private initEmitted = false;
@@ -208,28 +212,43 @@ export class Fmp4BoxStream extends EventEmitter {
   private fragmentPrefix: Buffer[] = [];
 
   write(chunk: Uint8Array): void {
-    if (
-      chunk.length > MAX_BUFFER_SIZE ||
-      this.pending.length > MAX_BUFFER_SIZE - chunk.length
-    ) {
-      this.failInvalidSize();
-      return;
-    }
-    this.pending = Buffer.concat([this.pending, Buffer.from(chunk)]);
+    let offset = 0;
+    while (offset < chunk.length) {
+      if (!this.currentBox) {
+        const requiredHeaderLength = this.requiredHeaderLength();
+        const copied = Math.min(requiredHeaderLength - this.headerLength, chunk.length - offset);
+        this.header.set(chunk.subarray(offset, offset + copied), this.headerLength);
+        this.headerLength += copied;
+        offset += copied;
+        if (this.headerLength < this.requiredHeaderLength()) continue;
 
-    while (this.pending.length >= BOX_HEADER_SIZE) {
-      const parsedHeader = this.readPendingHeader();
-      if (parsedHeader === undefined) return;
-      if (parsedHeader === null) {
-        this.failInvalidSize();
-        return;
+        const size = this.readHeaderSize();
+        if (size === undefined) {
+          this.failInvalidSize();
+          return;
+        }
+        this.currentBox = Buffer.allocUnsafe(size);
+        this.header.copy(this.currentBox, 0, 0, this.headerLength);
+        this.currentBoxLength = this.headerLength;
+        this.expectedBoxSize = size;
+        this.headerLength = 0;
       }
-      const { size } = parsedHeader;
-      if (this.pending.length < size) return;
 
-      const box = this.pending.subarray(0, size);
-      this.pending = this.pending.subarray(size);
-      this.handleBox(box);
+      const remaining = this.expectedBoxSize! - this.currentBoxLength;
+      if (remaining > 0) {
+        const copied = Math.min(remaining, chunk.length - offset);
+        this.currentBox!.set(chunk.subarray(offset, offset + copied), this.currentBoxLength);
+        this.currentBoxLength += copied;
+        offset += copied;
+      }
+
+      if (this.currentBoxLength === this.expectedBoxSize) {
+        const box = this.currentBox!;
+        this.currentBox = undefined;
+        this.currentBoxLength = 0;
+        this.expectedBoxSize = undefined;
+        this.handleBox(box);
+      }
     }
   }
 
@@ -238,7 +257,10 @@ export class Fmp4BoxStream extends EventEmitter {
   }
 
   reset(): void {
-    this.pending = Buffer.alloc(0);
+    this.headerLength = 0;
+    this.currentBox = undefined;
+    this.currentBoxLength = 0;
+    this.expectedBoxSize = undefined;
     this.ftyp = undefined;
     this.moov = undefined;
     this.initEmitted = false;
@@ -248,23 +270,26 @@ export class Fmp4BoxStream extends EventEmitter {
     this.fragmentPrefix = [];
   }
 
-  private readPendingHeader(): { size: number } | null | undefined {
-    let size = this.pending.readUInt32BE(0);
+  private requiredHeaderLength(): number {
+    if (this.headerLength < BOX_HEADER_SIZE) return BOX_HEADER_SIZE;
+    return this.header.readUInt32BE(0) === 1
+      ? EXTENDED_BOX_HEADER_SIZE
+      : BOX_HEADER_SIZE;
+  }
+
+  private readHeaderSize(): number | undefined {
+    let size = this.header.readUInt32BE(0);
+    let minimumSize = BOX_HEADER_SIZE;
     if (size === 1) {
-      if (this.pending.length < EXTENDED_BOX_HEADER_SIZE) return undefined;
-      const extendedSize = this.pending.readBigUInt64BE(BOX_HEADER_SIZE);
-      if (
-        extendedSize < BigInt(EXTENDED_BOX_HEADER_SIZE) ||
-        extendedSize > BigInt(Number.MAX_SAFE_INTEGER)
-      ) {
-        return null;
-      }
+      const extendedSize = this.header.readBigUInt64BE(BOX_HEADER_SIZE);
+      if (extendedSize > BigInt(Number.MAX_SAFE_INTEGER)) return undefined;
       size = Number(extendedSize);
-    } else if (size < BOX_HEADER_SIZE) {
-      return null;
+      minimumSize = EXTENDED_BOX_HEADER_SIZE;
     }
-    if (size > MAX_BOX_SIZE) return null;
-    return { size };
+    if (size < minimumSize || size > MAX_BOX_SIZE || size > MAX_BUFFER_SIZE) {
+      return undefined;
+    }
+    return size;
   }
 
   private handleBox(box: Buffer): void {
@@ -314,6 +339,8 @@ export class Fmp4BoxStream extends EventEmitter {
 
   private failInvalidSize(): void {
     this.reset();
-    this.emit("error", new Error("Invalid ISO-BMFF box size"));
+    if (this.listenerCount("error") > 0) {
+      this.emit("error", new Error("Invalid ISO-BMFF box size"));
+    }
   }
 }

--- a/packages/eufy-stream-server/src/h264-compatibility-relay.ts
+++ b/packages/eufy-stream-server/src/h264-compatibility-relay.ts
@@ -472,8 +472,15 @@ export function getSharedH264CompatibilityRelay(
 
   const relay = new H264CompatibilityRelay(options);
   sharedRelays.set(serialNumber, relay);
-  relay.on("stopped", () => {
-    if (sharedRelays.get(serialNumber) === relay) sharedRelays.delete(serialNumber);
-  });
   return relay;
+}
+
+/** Removes the factory entry only when the camera is permanently discarded. */
+export async function disposeSharedH264CompatibilityRelay(
+  serialNumber: string,
+): Promise<void> {
+  const relay = sharedRelays.get(serialNumber);
+  if (!relay) return;
+  sharedRelays.delete(serialNumber);
+  await relay.stop();
 }

--- a/packages/eufy-stream-server/src/h264-compatibility-relay.ts
+++ b/packages/eufy-stream-server/src/h264-compatibility-relay.ts
@@ -208,9 +208,19 @@ export class H264CompatibilityRelay extends EventEmitter {
       child = this.createChild(
         this.options.ffmpegPath!,
         [
-          "-hide_banner", "-loglevel", "error", "-f", "mp4", "-i", "pipe:0",
-          "-map", "0:v:0", "-map", "0:a?", "-c:v", "libx264", "-c:a", "aac",
-          "-movflags", "frag_keyframe+empty_moov+default_base_moof", "-f", "mp4", "pipe:1",
+          "-hide_banner", "-loglevel", "error",
+          // A persistent fMP4 pipe does not get an EOF to flush the MOV
+          // demuxer. Restrict probing/decoder reordering so complete moof
+          // fragments are processed as they arrive instead of on close.
+          "-threads", "1", "-blocksize", "4096", "-probesize", "4096", "-analyzeduration", "0",
+          "-f", "mp4", "-i", "pipe:0",
+          "-map", "0:v:0", "-map", "0:a?", "-c:v", "libx264",
+          "-preset", "ultrafast", "-tune", "zerolatency", "-g", "30", "-keyint_min", "30",
+          "-sc_threshold", "0", "-c:a", "aac",
+          // Fragment each output frame and flush the AVIO layer: fMP4 output
+          // then reaches relay consumers while the upstream remains connected.
+          "-movflags", "frag_every_frame+empty_moov+default_base_moof", "-flush_packets", "1",
+          "-f", "mp4", "pipe:1",
         ],
         { stdio: ["pipe", "pipe", "pipe"] },
       );

--- a/packages/eufy-stream-server/src/h264-compatibility-relay.ts
+++ b/packages/eufy-stream-server/src/h264-compatibility-relay.ts
@@ -70,6 +70,7 @@ export class H264CompatibilityRelay extends EventEmitter {
   private latestSyncFragment?: Buffer;
   private generation = 0;
   private stopping = false;
+  private disposed = false;
 
   public constructor(private readonly options: H264CompatibilityRelayOptions) {
     super();
@@ -92,7 +93,13 @@ export class H264CompatibilityRelay extends EventEmitter {
   }
 
   public async start(): Promise<void> {
+    if (this.disposed) {
+      throw new Error(`H264 compatibility relay for ${this.serialNumber} has been disposed`);
+    }
     if (this.stopPromise) await this.stopPromise;
+    if (this.disposed) {
+      throw new Error(`H264 compatibility relay for ${this.serialNumber} has been disposed`);
+    }
     if (this.startPromise) return this.startPromise;
     if (this.server && this.child && this.source && !this.stopping) return;
     const generation = ++this.generation;
@@ -158,6 +165,12 @@ export class H264CompatibilityRelay extends EventEmitter {
       this.stopPromise = undefined;
     });
     return this.stopPromise;
+  }
+
+  /** Permanently prevents this relay instance from being restarted. */
+  public async dispose(): Promise<void> {
+    this.disposed = true;
+    await this.stop();
   }
 
   private async listen(generation: number): Promise<void> {
@@ -228,6 +241,9 @@ export class H264CompatibilityRelay extends EventEmitter {
     child.on("exit", (code, signal) => {
       this.handleFailure(generation, "ffmpeg", new Error(`exited (${code ?? signal ?? "unknown"})`));
     });
+    child.stdin.on("error", (error) => this.handleFailure(generation, "ffmpeg stdin", error));
+    child.stdout.on("error", (error) => this.handleFailure(generation, "ffmpeg stdout", error));
+    child.stderr.on("error", (error) => this.handleFailure(generation, "ffmpeg stderr", error));
     child.stderr.on("data", () => undefined);
   }
 
@@ -265,7 +281,12 @@ export class H264CompatibilityRelay extends EventEmitter {
       }
     });
     this.ensureCurrent(generation);
-    source.pipe(this.child!.stdin);
+    try {
+      source.pipe(this.child!.stdin);
+    } catch (error) {
+      this.handleFailure(generation, "muxed source pipe", error);
+      throw error;
+    }
   }
 
   private acceptInit(init: Buffer): void {
@@ -285,6 +306,10 @@ export class H264CompatibilityRelay extends EventEmitter {
   }
 
   private addConsumer(socket: net.Socket): void {
+    if (this.stopping || this.disposed) {
+      socket.destroy();
+      return;
+    }
     this.clearLinger();
     const kind = this.classifyConsumer(socket);
     const consumer: Consumer = { socket, kind, queue: [], queuedBytes: 0, blocked: false, closed: false };
@@ -398,6 +423,18 @@ export class H264CompatibilityRelay extends EventEmitter {
   private async teardownInternal(): Promise<void> {
     this.stopping = true;
     this.clearLinger();
+    const server = this.server;
+    this.server = undefined;
+    // Stop accepting before any asynchronous drain/child/source cleanup.
+    const serverClosed = server
+      ? new Promise<void>((resolve) => {
+          try {
+            server.close(() => resolve());
+          } catch {
+            resolve();
+          }
+        })
+      : Promise.resolve();
     for (const consumer of [...this.consumers.values()]) {
       consumer.socket.destroy();
       this.removeConsumer(consumer);
@@ -409,12 +446,18 @@ export class H264CompatibilityRelay extends EventEmitter {
     parser?.removeAllListeners();
     if (child) {
       child.stdout.removeAllListeners("data");
+      child.stdin.removeAllListeners("error");
+      child.stdout.removeAllListeners("error");
+      child.stderr.removeAllListeners("error");
       child.stderr.removeAllListeners("data");
       child.removeAllListeners("error");
       child.removeAllListeners("exit");
       // A delayed child-process error after teardown must not become an
       // unhandled EventEmitter error while the OS finishes reaping it.
       child.on("error", () => undefined);
+      child.stdin.on("error", () => undefined);
+      child.stdout.on("error", () => undefined);
+      child.stderr.on("error", () => undefined);
       try { child.kill(); } catch { /* already exited */ }
     }
     const source = this.source;
@@ -429,12 +472,9 @@ export class H264CompatibilityRelay extends EventEmitter {
       }
       source.removeAllListeners("error");
       source.removeAllListeners("close");
+      source.on("error", () => undefined);
     }
-    if (this.server) {
-      const server = this.server;
-      this.server = undefined;
-      await new Promise<void>((resolve) => server.close(() => resolve()));
-    }
+    await serverClosed;
     this.baseLease?.release();
     this.baseLease = undefined;
     this.resetCache();
@@ -482,5 +522,5 @@ export async function disposeSharedH264CompatibilityRelay(
   const relay = sharedRelays.get(serialNumber);
   if (!relay) return;
   sharedRelays.delete(serialNumber);
-  await relay.stop();
+  await relay.dispose();
 }

--- a/packages/eufy-stream-server/src/h264-compatibility-relay.ts
+++ b/packages/eufy-stream-server/src/h264-compatibility-relay.ts
@@ -1,0 +1,365 @@
+import { ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import * as net from "node:net";
+import { Fmp4BoxStream, findVideoTrackId, moofFirstSampleIsSync } from "./fmp4-box-stream";
+import {
+  CompatibilityEncoderConsumerKind,
+  CompatibilityEncoderLease,
+  CompatibilityEncoderPool,
+} from "./compatibility-encoder-pool";
+
+const MAX_QUEUED_FRAGMENTS = 2;
+const MAX_QUEUED_BYTES = 1024 * 1024;
+
+type Child = Pick<ChildProcessWithoutNullStreams, "stdin" | "stdout" | "stderr" | "kill"> &
+  EventEmitter;
+
+export interface H264CompatibilityRelayOptions {
+  /** Camera serial number; cameraId is retained as a small compatibility alias. */
+  serialNumber?: string;
+  cameraId?: string;
+  name?: string;
+  getMuxedPort?: () => number | undefined;
+  streamServer?: { getMuxedPort(): number | undefined };
+  ffmpegPath?: string;
+  pool?: CompatibilityEncoderPool;
+  lingerMs?: number;
+  classifyConsumer?: (socket: net.Socket) => CompatibilityEncoderConsumerKind;
+  createChildProcess?: (
+    command: string,
+    args: readonly string[],
+    options: Parameters<typeof spawn>[2],
+  ) => Child;
+  net?: Pick<typeof net, "createServer" | "createConnection">;
+}
+
+interface Consumer {
+  socket: net.Socket;
+  queue: Buffer[];
+  queuedBytes: number;
+  blocked: boolean;
+  closed: boolean;
+  kind: CompatibilityEncoderConsumerKind;
+  protectionLease?: CompatibilityEncoderLease;
+}
+
+/**
+ * One loopback TCP endpoint which converts the StreamServer's muxed fMP4
+ * output once and fans its H.264/AAC fMP4 output to every downstream client.
+ */
+export class H264CompatibilityRelay extends EventEmitter {
+  private readonly serialNumber: string;
+  private readonly netApi: Pick<typeof net, "createServer" | "createConnection">;
+  private readonly pool: CompatibilityEncoderPool;
+  private readonly lingerMs: number;
+  private readonly classifyConsumer: (socket: net.Socket) => CompatibilityEncoderConsumerKind;
+  private readonly createChild: NonNullable<H264CompatibilityRelayOptions["createChildProcess"]>;
+  private server?: net.Server;
+  private source?: net.Socket;
+  private child?: Child;
+  private parser?: Fmp4BoxStream;
+  private startPromise?: Promise<void>;
+  private stopPromise?: Promise<void>;
+  private baseLease?: CompatibilityEncoderLease;
+  private consumers = new Map<net.Socket, Consumer>();
+  private lingerTimer?: ReturnType<typeof setTimeout>;
+  private init?: Buffer;
+  private videoTrackId?: number;
+  private latestSyncFragment?: Buffer;
+  private generation = 0;
+  private stopping = false;
+
+  public constructor(private readonly options: H264CompatibilityRelayOptions) {
+    super();
+    this.serialNumber = options.serialNumber ?? options.cameraId ?? "";
+    this.netApi = options.net ?? net;
+    this.pool = options.pool ?? new CompatibilityEncoderPool();
+    this.lingerMs = options.lingerMs ?? 10_000;
+    this.classifyConsumer = options.classifyConsumer ?? (() => "interactive");
+    this.createChild = options.createChildProcess ?? ((command, args, spawnOptions) =>
+      spawn(command, args, spawnOptions) as Child);
+  }
+
+  public getPort(): number | undefined {
+    const address = this.server?.address();
+    return address && typeof address === "object" ? address.port : undefined;
+  }
+
+  public get generationId(): number {
+    return this.generation;
+  }
+
+  public async start(): Promise<void> {
+    if (this.startPromise) return this.startPromise;
+    if (this.server && this.child && this.source && !this.stopping) return;
+    this.startPromise = this.startInternal().finally(() => {
+      this.startPromise = undefined;
+    });
+    return this.startPromise;
+  }
+
+  private async startInternal(): Promise<void> {
+    if (!this.serialNumber) {
+      throw new Error("Cannot start H264 compatibility relay: camera serial number is required");
+    }
+    if (!this.options.ffmpegPath) {
+      throw new Error(
+        `Cannot start H264 compatibility relay for ${this.serialNumber}: ffmpeg path is required`,
+      );
+    }
+    const sourcePort = this.options.getMuxedPort?.() ?? this.options.streamServer?.getMuxedPort();
+    if (!sourcePort) {
+      throw new Error(
+        `Cannot start H264 compatibility relay for ${this.serialNumber}: StreamServer muxed source is unavailable`,
+      );
+    }
+
+    this.stopping = false;
+    this.clearLinger();
+    this.resetCache();
+    this.generation += 1;
+    try {
+      this.baseLease = this.pool.acquire({
+        serialNumber: this.serialNumber,
+        name: this.options.name,
+        consumerKind: "prebuffer",
+        onPreempt: () => this.handlePreempt(),
+      });
+      await this.listen();
+      this.spawnChild();
+      await this.connectSource(sourcePort);
+      this.emit("started", this.generation);
+    } catch (error) {
+      await this.teardown();
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(`Cannot start H264 compatibility relay for ${this.serialNumber}: ${detail}`);
+    }
+  }
+
+  public async stop(): Promise<void> {
+    this.clearLinger();
+    if (this.stopPromise) return this.stopPromise;
+    if (!this.server && !this.source && !this.child && !this.baseLease) return;
+    this.stopPromise = this.teardown().finally(() => {
+      this.stopPromise = undefined;
+    });
+    return this.stopPromise;
+  }
+
+  private async listen(): Promise<void> {
+    this.server = this.netApi.createServer((socket) => this.addConsumer(socket));
+    await new Promise<void>((resolve, reject) => {
+      const server = this.server!;
+      const onError = (error: Error) => {
+        server.off("listening", onListening);
+        reject(error);
+      };
+      const onListening = () => {
+        server.off("error", onError);
+        resolve();
+      };
+      server.once("error", onError);
+      server.once("listening", onListening);
+      server.listen(0, "127.0.0.1");
+    });
+  }
+
+  private spawnChild(): void {
+    let child: Child;
+    try {
+      child = this.createChild(
+        this.options.ffmpegPath!,
+        [
+          "-hide_banner", "-loglevel", "error", "-f", "mp4", "-i", "pipe:0",
+          "-map", "0:v:0", "-map", "0:a?", "-c:v", "libx264", "-c:a", "aac",
+          "-movflags", "frag_keyframe+empty_moov+default_base_moof", "-f", "mp4", "pipe:1",
+        ],
+        { stdio: ["pipe", "pipe", "pipe"] },
+      );
+    } catch (error) {
+      throw new Error(`failed to spawn ffmpeg: ${error instanceof Error ? error.message : error}`);
+    }
+    if (!child?.stdin || !child.stdout) throw new Error("ffmpeg did not provide stdio pipes");
+    this.child = child;
+    this.parser = new Fmp4BoxStream();
+    this.parser.on("init", (init: Buffer) => this.acceptInit(init));
+    this.parser.on("fragment", (fragment: Buffer) => this.acceptFragment(fragment));
+    this.parser.on("error", (error) => this.handleFailure("fMP4 output", error));
+    child.stdout.on("data", (chunk: Buffer) => this.parser?.write(chunk));
+    child.on("error", (error) => this.handleFailure("ffmpeg", error));
+    child.on("exit", (code, signal) => {
+      if (!this.stopping) this.handleFailure("ffmpeg", new Error(`exited (${code ?? signal ?? "unknown"})`));
+    });
+    child.stderr.on("data", () => undefined);
+  }
+
+  private async connectSource(port: number): Promise<void> {
+    const source = this.netApi.createConnection({ port, host: "127.0.0.1" });
+    this.source = source;
+    await new Promise<void>((resolve, reject) => {
+      const onError = (error: Error) => {
+        source.off("connect", onConnect);
+        reject(new Error(`muxed source unavailable on port ${port}: ${error.message}`));
+      };
+      const onConnect = () => {
+        source.off("error", onError);
+        resolve();
+      };
+      source.once("error", onError);
+      source.once("connect", onConnect);
+    });
+    source.on("error", (error) => {
+      if (this.source === source) this.handleFailure("muxed source", error);
+    });
+    source.on("close", () => {
+      if (this.source === source && !this.stopping) {
+        this.handleFailure("muxed source", new Error("disconnected"));
+      }
+    });
+    source.pipe(this.child!.stdin);
+  }
+
+  private acceptInit(init: Buffer): void {
+    const trackId = findVideoTrackId(init);
+    this.init = init;
+    this.videoTrackId = trackId;
+    this.latestSyncFragment = undefined;
+    for (const consumer of this.consumers.values()) this.send(consumer, init);
+  }
+
+  private acceptFragment(fragment: Buffer): void {
+    if (!this.init || this.videoTrackId === undefined) return;
+    if (moofFirstSampleIsSync(fragment, this.videoTrackId)) {
+      this.latestSyncFragment = fragment;
+    }
+    this.broadcast(fragment);
+  }
+
+  private addConsumer(socket: net.Socket): void {
+    this.clearLinger();
+    const kind = this.classifyConsumer(socket);
+    const consumer: Consumer = { socket, kind, queue: [], queuedBytes: 0, blocked: false, closed: false };
+    // An interactive attachment protects the otherwise-prebuffer relay from pool preemption.
+    if (kind === "interactive" && this.baseLease) {
+      try {
+        consumer.protectionLease = this.pool.acquire({
+          serialNumber: this.serialNumber,
+          name: this.options.name,
+          consumerKind: "interactive",
+          onPreempt: () => this.handlePreempt(),
+        });
+      } catch (error) {
+        socket.destroy(error instanceof Error ? error : undefined);
+        return;
+      }
+    }
+    this.consumers.set(socket, consumer);
+    socket.on("drain", () => this.flush(consumer));
+    socket.on("close", () => this.removeConsumer(consumer));
+    socket.on("error", () => this.removeConsumer(consumer));
+    if (this.init && this.latestSyncFragment) {
+      this.send(consumer, Buffer.concat([this.init, this.latestSyncFragment]));
+    }
+  }
+
+  private removeConsumer(consumer: Consumer): void {
+    if (consumer.closed) return;
+    consumer.closed = true;
+    this.consumers.delete(consumer.socket);
+    consumer.protectionLease?.release();
+    if (this.consumers.size === 0 && !this.stopping) {
+      this.lingerTimer = setTimeout(() => void this.stop(), this.lingerMs);
+    }
+  }
+
+  private broadcast(fragment: Buffer): void {
+    for (const consumer of this.consumers.values()) this.send(consumer, fragment);
+  }
+
+  private send(consumer: Consumer, fragment: Buffer): void {
+    if (consumer.closed || consumer.socket.destroyed) return;
+    if (consumer.blocked) {
+      this.queue(consumer, fragment);
+      return;
+    }
+    if (!consumer.socket.write(fragment)) consumer.blocked = true;
+  }
+
+  private queue(consumer: Consumer, fragment: Buffer): void {
+    if (
+      consumer.queue.length >= MAX_QUEUED_FRAGMENTS ||
+      consumer.queuedBytes + fragment.length > MAX_QUEUED_BYTES
+    ) {
+      consumer.socket.destroy(new Error("H264 compatibility relay consumer overflow"));
+      return;
+    }
+    consumer.queue.push(fragment);
+    consumer.queuedBytes += fragment.length;
+  }
+
+  private flush(consumer: Consumer): void {
+    consumer.blocked = false;
+    while (!consumer.blocked && consumer.queue.length) {
+      const fragment = consumer.queue.shift()!;
+      consumer.queuedBytes -= fragment.length;
+      if (!consumer.socket.write(fragment)) consumer.blocked = true;
+    }
+  }
+
+  private handlePreempt(): void {
+    if (this.stopping) return;
+    this.emit("preempted", { serialNumber: this.serialNumber, reason: "encoder-pool-preempted" });
+    for (const consumer of this.consumers.values()) {
+      consumer.socket.destroy(new Error("H264 compatibility relay preempted by encoder pool"));
+    }
+    void this.stop();
+  }
+
+  private handleFailure(component: string, error: unknown): void {
+    if (this.stopping) return;
+    this.resetCache();
+    const failure = new Error(
+      `H264 compatibility relay ${component} failure: ${error instanceof Error ? error.message : error}`,
+    );
+    this.emit("failure", failure);
+    if (this.listenerCount("error") > 0) this.emit("error", failure);
+    void this.stop();
+  }
+
+  private resetCache(): void {
+    this.init = undefined;
+    this.videoTrackId = undefined;
+    this.latestSyncFragment = undefined;
+    this.parser?.reset();
+  }
+
+  private clearLinger(): void {
+    if (this.lingerTimer) clearTimeout(this.lingerTimer);
+    this.lingerTimer = undefined;
+  }
+
+  private async teardown(): Promise<void> {
+    this.stopping = true;
+    this.clearLinger();
+    for (const consumer of [...this.consumers.values()]) {
+      consumer.socket.destroy();
+      this.removeConsumer(consumer);
+    }
+    try { this.child?.kill(); } catch { /* already exited */ }
+    this.child = undefined;
+    this.parser = undefined;
+    const source = this.source;
+    this.source = undefined;
+    if (source) source.destroy();
+    if (this.server) {
+      const server = this.server;
+      this.server = undefined;
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+    this.baseLease?.release();
+    this.baseLease = undefined;
+    this.resetCache();
+    this.stopping = false;
+    this.emit("stopped");
+  }
+}

--- a/packages/eufy-stream-server/src/h264-compatibility-relay.ts
+++ b/packages/eufy-stream-server/src/h264-compatibility-relay.ts
@@ -10,6 +10,7 @@ import {
 
 const MAX_QUEUED_FRAGMENTS = 2;
 const MAX_QUEUED_BYTES = 1024 * 1024;
+const DEFAULT_CHILD_EXIT_TIMEOUT_MS = 2_000;
 const defaultCompatibilityEncoderPool = new CompatibilityEncoderPool();
 
 type Child = Pick<ChildProcessWithoutNullStreams, "stdin" | "stdout" | "stderr" | "kill"> &
@@ -25,6 +26,8 @@ export interface H264CompatibilityRelayOptions {
   ffmpegPath?: string;
   pool?: CompatibilityEncoderPool;
   lingerMs?: number;
+  /** Bounded wait before escalating a graceful FFmpeg shutdown to SIGKILL. */
+  childExitTimeoutMs?: number;
   classifyConsumer?: (socket: net.Socket) => CompatibilityEncoderConsumerKind;
   createChildProcess?: (
     command: string,
@@ -53,6 +56,7 @@ export class H264CompatibilityRelay extends EventEmitter {
   private readonly netApi: Pick<typeof net, "createServer" | "createConnection">;
   private readonly pool: CompatibilityEncoderPool;
   private readonly lingerMs: number;
+  private readonly childExitTimeoutMs: number;
   private readonly classifyConsumer: (socket: net.Socket) => CompatibilityEncoderConsumerKind;
   private readonly createChild: NonNullable<H264CompatibilityRelayOptions["createChildProcess"]>;
   private server?: net.Server;
@@ -78,6 +82,10 @@ export class H264CompatibilityRelay extends EventEmitter {
     this.netApi = options.net ?? net;
     this.pool = options.pool ?? defaultCompatibilityEncoderPool;
     this.lingerMs = options.lingerMs ?? 10_000;
+    this.childExitTimeoutMs = options.childExitTimeoutMs ?? DEFAULT_CHILD_EXIT_TIMEOUT_MS;
+    if (this.childExitTimeoutMs < 0) {
+      throw new RangeError("H264 compatibility relay child exit timeout must not be negative");
+    }
     this.classifyConsumer = options.classifyConsumer ?? (() => "interactive");
     this.createChild = options.createChildProcess ?? ((command, args, spawnOptions) =>
       spawn(command, args, spawnOptions) as Child);
@@ -468,7 +476,7 @@ export class H264CompatibilityRelay extends EventEmitter {
       child.stdin.on("error", () => undefined);
       child.stdout.on("error", () => undefined);
       child.stderr.on("error", () => undefined);
-      try { child.kill(); } catch { /* already exited */ }
+      await this.terminateChild(child);
     }
     const source = this.source;
     this.source = undefined;
@@ -494,6 +502,42 @@ export class H264CompatibilityRelay extends EventEmitter {
 
   private isCurrent(generation: number): boolean {
     return generation === this.generation && !this.stopping;
+  }
+
+  /**
+   * Reap the owned FFmpeg process before completing relay teardown. Merely
+   * sending SIGTERM leaves its stdio handles alive under Jest (and can keep a
+   * plugin process alive indefinitely), so stop waits for exit/close and only
+   * then releases the relay's remaining resources.
+   */
+  private async terminateChild(child: Child): Promise<void> {
+    if (await this.signalAndWaitForChildExit(child, "SIGTERM")) return;
+    await this.signalAndWaitForChildExit(child, "SIGKILL");
+  }
+
+  private async signalAndWaitForChildExit(
+    child: Child,
+    signal: NodeJS.Signals,
+  ): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const done = (exited: boolean) => {
+        if (timer) clearTimeout(timer);
+        child.off("exit", onExit);
+        child.off("close", onClose);
+        resolve(exited);
+      };
+      const onExit = () => done(true);
+      const onClose = () => done(true);
+      timer = setTimeout(() => done(false), this.childExitTimeoutMs);
+      child.once("exit", onExit);
+      child.once("close", onClose);
+      try {
+        if (child.kill(signal) === false) done(true);
+      } catch {
+        done(true);
+      }
+    });
   }
 
   private ensureCurrent(generation: number): void {

--- a/packages/eufy-stream-server/src/h264-compatibility-relay.ts
+++ b/packages/eufy-stream-server/src/h264-compatibility-relay.ts
@@ -10,6 +10,7 @@ import {
 
 const MAX_QUEUED_FRAGMENTS = 2;
 const MAX_QUEUED_BYTES = 1024 * 1024;
+const defaultCompatibilityEncoderPool = new CompatibilityEncoderPool();
 
 type Child = Pick<ChildProcessWithoutNullStreams, "stdin" | "stdout" | "stderr" | "kill"> &
   EventEmitter;
@@ -60,6 +61,7 @@ export class H264CompatibilityRelay extends EventEmitter {
   private parser?: Fmp4BoxStream;
   private startPromise?: Promise<void>;
   private stopPromise?: Promise<void>;
+  private teardownPromise?: Promise<void>;
   private baseLease?: CompatibilityEncoderLease;
   private consumers = new Map<net.Socket, Consumer>();
   private lingerTimer?: ReturnType<typeof setTimeout>;
@@ -73,7 +75,7 @@ export class H264CompatibilityRelay extends EventEmitter {
     super();
     this.serialNumber = options.serialNumber ?? options.cameraId ?? "";
     this.netApi = options.net ?? net;
-    this.pool = options.pool ?? new CompatibilityEncoderPool();
+    this.pool = options.pool ?? defaultCompatibilityEncoderPool;
     this.lingerMs = options.lingerMs ?? 10_000;
     this.classifyConsumer = options.classifyConsumer ?? (() => "interactive");
     this.createChild = options.createChildProcess ?? ((command, args, spawnOptions) =>
@@ -90,15 +92,17 @@ export class H264CompatibilityRelay extends EventEmitter {
   }
 
   public async start(): Promise<void> {
+    if (this.stopPromise) await this.stopPromise;
     if (this.startPromise) return this.startPromise;
     if (this.server && this.child && this.source && !this.stopping) return;
-    this.startPromise = this.startInternal().finally(() => {
+    const generation = ++this.generation;
+    this.startPromise = this.startInternal(generation).finally(() => {
       this.startPromise = undefined;
     });
     return this.startPromise;
   }
 
-  private async startInternal(): Promise<void> {
+  private async startInternal(generation: number): Promise<void> {
     if (!this.serialNumber) {
       throw new Error("Cannot start H264 compatibility relay: camera serial number is required");
     }
@@ -114,10 +118,9 @@ export class H264CompatibilityRelay extends EventEmitter {
       );
     }
 
-    this.stopping = false;
+    this.ensureCurrent(generation);
     this.clearLinger();
     this.resetCache();
-    this.generation += 1;
     try {
       this.baseLease = this.pool.acquire({
         serialNumber: this.serialNumber,
@@ -125,12 +128,17 @@ export class H264CompatibilityRelay extends EventEmitter {
         consumerKind: "prebuffer",
         onPreempt: () => this.handlePreempt(),
       });
-      await this.listen();
-      this.spawnChild();
-      await this.connectSource(sourcePort);
-      this.emit("started", this.generation);
+      await this.listen(generation);
+      this.ensureCurrent(generation);
+      this.spawnChild(generation);
+      await this.connectSource(sourcePort, generation);
+      this.ensureCurrent(generation);
+      this.emit("started", generation);
     } catch (error) {
-      await this.teardown();
+      if (generation === this.generation && !this.stopping) await this.teardown();
+      if (generation !== this.generation || this.stopping) {
+        throw new Error(`H264 compatibility relay start was cancelled for ${this.serialNumber}`);
+      }
       const detail = error instanceof Error ? error.message : String(error);
       throw new Error(`Cannot start H264 compatibility relay for ${this.serialNumber}: ${detail}`);
     }
@@ -140,31 +148,48 @@ export class H264CompatibilityRelay extends EventEmitter {
     this.clearLinger();
     if (this.stopPromise) return this.stopPromise;
     if (!this.server && !this.source && !this.child && !this.baseLease) return;
-    this.stopPromise = this.teardown().finally(() => {
+    const starting = this.startPromise;
+    this.generation += 1;
+    this.stopping = true;
+    this.stopPromise = (async () => {
+      await this.teardown();
+      await starting?.catch(() => undefined);
+    })().finally(() => {
       this.stopPromise = undefined;
     });
     return this.stopPromise;
   }
 
-  private async listen(): Promise<void> {
+  private async listen(generation: number): Promise<void> {
     this.server = this.netApi.createServer((socket) => this.addConsumer(socket));
     await new Promise<void>((resolve, reject) => {
       const server = this.server!;
-      const onError = (error: Error) => {
+      const cleanup = () => {
+        server.off("error", onError);
         server.off("listening", onListening);
+        server.off("close", onClose);
+      };
+      const onError = (error: Error) => {
+        cleanup();
         reject(error);
       };
       const onListening = () => {
-        server.off("error", onError);
+        cleanup();
         resolve();
+      };
+      const onClose = () => {
+        cleanup();
+        reject(new Error("relay stopped while loopback listener was starting"));
       };
       server.once("error", onError);
       server.once("listening", onListening);
+      server.once("close", onClose);
       server.listen(0, "127.0.0.1");
     });
+    this.ensureCurrent(generation);
   }
 
-  private spawnChild(): void {
+  private spawnChild(generation: number): void {
     let child: Child;
     try {
       child = this.createChild(
@@ -181,41 +206,65 @@ export class H264CompatibilityRelay extends EventEmitter {
     }
     if (!child?.stdin || !child.stdout) throw new Error("ffmpeg did not provide stdio pipes");
     this.child = child;
-    this.parser = new Fmp4BoxStream();
-    this.parser.on("init", (init: Buffer) => this.acceptInit(init));
-    this.parser.on("fragment", (fragment: Buffer) => this.acceptFragment(fragment));
-    this.parser.on("error", (error) => this.handleFailure("fMP4 output", error));
-    child.stdout.on("data", (chunk: Buffer) => this.parser?.write(chunk));
-    child.on("error", (error) => this.handleFailure("ffmpeg", error));
+    const parser = new Fmp4BoxStream();
+    this.parser = parser;
+    parser.on("init", (init: Buffer) => {
+      if (this.isCurrent(generation) && this.parser === parser && this.child === child) {
+        this.acceptInit(init);
+      }
+    });
+    parser.on("fragment", (fragment: Buffer) => {
+      if (this.isCurrent(generation) && this.parser === parser && this.child === child) {
+        this.acceptFragment(fragment);
+      }
+    });
+    parser.on("error", (error) => this.handleFailure(generation, "fMP4 output", error));
+    child.stdout.on("data", (chunk: Buffer) => {
+      if (this.isCurrent(generation) && this.parser === parser && this.child === child) {
+        parser.write(chunk);
+      }
+    });
+    child.on("error", (error) => this.handleFailure(generation, "ffmpeg", error));
     child.on("exit", (code, signal) => {
-      if (!this.stopping) this.handleFailure("ffmpeg", new Error(`exited (${code ?? signal ?? "unknown"})`));
+      this.handleFailure(generation, "ffmpeg", new Error(`exited (${code ?? signal ?? "unknown"})`));
     });
     child.stderr.on("data", () => undefined);
   }
 
-  private async connectSource(port: number): Promise<void> {
+  private async connectSource(port: number, generation: number): Promise<void> {
     const source = this.netApi.createConnection({ port, host: "127.0.0.1" });
     this.source = source;
     await new Promise<void>((resolve, reject) => {
-      const onError = (error: Error) => {
+      const cleanup = () => {
+        source.off("error", onError);
         source.off("connect", onConnect);
+        source.off("close", onClose);
+      };
+      const onError = (error: Error) => {
+        cleanup();
         reject(new Error(`muxed source unavailable on port ${port}: ${error.message}`));
       };
       const onConnect = () => {
-        source.off("error", onError);
+        cleanup();
         resolve();
+      };
+      const onClose = () => {
+        cleanup();
+        reject(new Error(`muxed source unavailable on port ${port}: disconnected`));
       };
       source.once("error", onError);
       source.once("connect", onConnect);
+      source.once("close", onClose);
     });
     source.on("error", (error) => {
-      if (this.source === source) this.handleFailure("muxed source", error);
+      if (this.source === source) this.handleFailure(generation, "muxed source", error);
     });
     source.on("close", () => {
-      if (this.source === source && !this.stopping) {
-        this.handleFailure("muxed source", new Error("disconnected"));
+      if (this.source === source) {
+        this.handleFailure(generation, "muxed source", new Error("disconnected"));
       }
     });
+    this.ensureCurrent(generation);
     source.pipe(this.child!.stdin);
   }
 
@@ -315,8 +364,8 @@ export class H264CompatibilityRelay extends EventEmitter {
     void this.stop();
   }
 
-  private handleFailure(component: string, error: unknown): void {
-    if (this.stopping) return;
+  private handleFailure(generation: number, component: string, error: unknown): void {
+    if (!this.isCurrent(generation)) return;
     this.resetCache();
     const failure = new Error(
       `H264 compatibility relay ${component} failure: ${error instanceof Error ? error.message : error}`,
@@ -339,18 +388,48 @@ export class H264CompatibilityRelay extends EventEmitter {
   }
 
   private async teardown(): Promise<void> {
+    if (this.teardownPromise) return this.teardownPromise;
+    this.teardownPromise = this.teardownInternal().finally(() => {
+      this.teardownPromise = undefined;
+    });
+    return this.teardownPromise;
+  }
+
+  private async teardownInternal(): Promise<void> {
     this.stopping = true;
     this.clearLinger();
     for (const consumer of [...this.consumers.values()]) {
       consumer.socket.destroy();
       this.removeConsumer(consumer);
     }
-    try { this.child?.kill(); } catch { /* already exited */ }
+    const child = this.child;
     this.child = undefined;
+    const parser = this.parser;
     this.parser = undefined;
+    parser?.removeAllListeners();
+    if (child) {
+      child.stdout.removeAllListeners("data");
+      child.stderr.removeAllListeners("data");
+      child.removeAllListeners("error");
+      child.removeAllListeners("exit");
+      // A delayed child-process error after teardown must not become an
+      // unhandled EventEmitter error while the OS finishes reaping it.
+      child.on("error", () => undefined);
+      try { child.kill(); } catch { /* already exited */ }
+    }
     const source = this.source;
     this.source = undefined;
-    if (source) source.destroy();
+    if (source) {
+      (source as unknown as { unpipe?: (destination?: unknown) => void }).unpipe?.(child?.stdin);
+      if (!source.destroyed) {
+        await new Promise<void>((resolve) => {
+          source.once("close", resolve);
+          source.destroy();
+        });
+      }
+      source.removeAllListeners("error");
+      source.removeAllListeners("close");
+    }
     if (this.server) {
       const server = this.server;
       this.server = undefined;
@@ -362,4 +441,39 @@ export class H264CompatibilityRelay extends EventEmitter {
     this.stopping = false;
     this.emit("stopped");
   }
+
+  private isCurrent(generation: number): boolean {
+    return generation === this.generation && !this.stopping;
+  }
+
+  private ensureCurrent(generation: number): void {
+    if (!this.isCurrent(generation)) {
+      throw new Error(`H264 compatibility relay start was cancelled for ${this.serialNumber}`);
+    }
+  }
+}
+
+const sharedRelays = new Map<string, H264CompatibilityRelay>();
+
+/**
+ * Returns the process-wide relay for a camera. This is the default entry
+ * point for consumers so independently-created downstream sessions cannot
+ * accidentally launch a second encoder for the same camera.
+ */
+export function getSharedH264CompatibilityRelay(
+  options: H264CompatibilityRelayOptions,
+): H264CompatibilityRelay {
+  const serialNumber = options.serialNumber ?? options.cameraId;
+  if (!serialNumber) {
+    throw new Error("Cannot create shared H264 compatibility relay: camera serial number is required");
+  }
+  const existing = sharedRelays.get(serialNumber);
+  if (existing) return existing;
+
+  const relay = new H264CompatibilityRelay(options);
+  sharedRelays.set(serialNumber, relay);
+  relay.on("stopped", () => {
+    if (sharedRelays.get(serialNumber) === relay) sharedRelays.delete(serialNumber);
+  });
+  return relay;
 }

--- a/packages/eufy-stream-server/src/index.ts
+++ b/packages/eufy-stream-server/src/index.ts
@@ -49,5 +49,14 @@ export type {
   CompatibilityEncoderLease,
   CompatibilityEncoderPoolOptions,
 } from "./compatibility-encoder-pool";
+export { ThermalGovernor } from "./thermal-governor";
+
+export type { StreamServerOptions } from "./stream-server";
+export type {
+  TemperatureReader,
+  ThermalGovernorOptions,
+  ThermalGovernorReason,
+  ThermalGovernorStatus,
+} from "./thermal-governor";
 
 export type { StreamData, ConnectionInfo, ServerStats, NALUnit } from "./types";

--- a/packages/eufy-stream-server/src/index.ts
+++ b/packages/eufy-stream-server/src/index.ts
@@ -25,7 +25,14 @@
 export { StreamServer } from "./stream-server";
 export { ConnectionManager } from "./connection-manager";
 export { H264Parser } from "./h264-parser";
+export { ThermalGovernor } from "./thermal-governor";
 
 export type { StreamServerOptions } from "./stream-server";
+export type {
+  TemperatureReader,
+  ThermalGovernorOptions,
+  ThermalGovernorReason,
+  ThermalGovernorStatus,
+} from "./thermal-governor";
 
 export type { StreamData, ConnectionInfo, ServerStats, NALUnit } from "./types";

--- a/packages/eufy-stream-server/src/index.ts
+++ b/packages/eufy-stream-server/src/index.ts
@@ -26,6 +26,7 @@ export { StreamServer } from "./stream-server";
 export { ConnectionManager } from "./connection-manager";
 export { H264Parser } from "./h264-parser";
 export {
+  disposeSharedH264CompatibilityRelay,
   getSharedH264CompatibilityRelay,
   H264CompatibilityRelay,
 } from "./h264-compatibility-relay";

--- a/packages/eufy-stream-server/src/index.ts
+++ b/packages/eufy-stream-server/src/index.ts
@@ -25,7 +25,10 @@
 export { StreamServer } from "./stream-server";
 export { ConnectionManager } from "./connection-manager";
 export { H264Parser } from "./h264-parser";
-export { H264CompatibilityRelay } from "./h264-compatibility-relay";
+export {
+  getSharedH264CompatibilityRelay,
+  H264CompatibilityRelay,
+} from "./h264-compatibility-relay";
 export {
   CompatibilityEncoderCapacityError,
   CompatibilityEncoderPool,

--- a/packages/eufy-stream-server/src/index.ts
+++ b/packages/eufy-stream-server/src/index.ts
@@ -25,6 +25,11 @@
 export { StreamServer } from "./stream-server";
 export { ConnectionManager } from "./connection-manager";
 export { H264Parser } from "./h264-parser";
+export {
+  Fmp4BoxStream,
+  findVideoTrackId,
+  moofFirstSampleIsSync,
+} from "./fmp4-box-stream";
 
 export type { StreamServerOptions } from "./stream-server";
 

--- a/packages/eufy-stream-server/src/index.ts
+++ b/packages/eufy-stream-server/src/index.ts
@@ -26,11 +26,22 @@ export { StreamServer } from "./stream-server";
 export { ConnectionManager } from "./connection-manager";
 export { H264Parser } from "./h264-parser";
 export {
+  CompatibilityEncoderCapacityError,
+  CompatibilityEncoderPool,
+} from "./compatibility-encoder-pool";
+export {
   Fmp4BoxStream,
   findVideoTrackId,
   moofFirstSampleIsSync,
 } from "./fmp4-box-stream";
 
 export type { StreamServerOptions } from "./stream-server";
+export type {
+  CompatibilityEncoderAcquireRequest,
+  CompatibilityEncoderConsumerKind,
+  CompatibilityEncoderHolder,
+  CompatibilityEncoderLease,
+  CompatibilityEncoderPoolOptions,
+} from "./compatibility-encoder-pool";
 
 export type { StreamData, ConnectionInfo, ServerStats, NALUnit } from "./types";

--- a/packages/eufy-stream-server/src/index.ts
+++ b/packages/eufy-stream-server/src/index.ts
@@ -51,7 +51,6 @@ export type {
 } from "./compatibility-encoder-pool";
 export { ThermalGovernor } from "./thermal-governor";
 
-export type { StreamServerOptions } from "./stream-server";
 export type {
   TemperatureReader,
   ThermalGovernorOptions,

--- a/packages/eufy-stream-server/src/index.ts
+++ b/packages/eufy-stream-server/src/index.ts
@@ -25,6 +25,7 @@
 export { StreamServer } from "./stream-server";
 export { ConnectionManager } from "./connection-manager";
 export { H264Parser } from "./h264-parser";
+export { H264CompatibilityRelay } from "./h264-compatibility-relay";
 export {
   CompatibilityEncoderCapacityError,
   CompatibilityEncoderPool,
@@ -36,6 +37,7 @@ export {
 } from "./fmp4-box-stream";
 
 export type { StreamServerOptions } from "./stream-server";
+export type { H264CompatibilityRelayOptions } from "./h264-compatibility-relay";
 export type {
   CompatibilityEncoderAcquireRequest,
   CompatibilityEncoderConsumerKind,

--- a/packages/eufy-stream-server/src/stream-server.ts
+++ b/packages/eufy-stream-server/src/stream-server.ts
@@ -1417,6 +1417,12 @@ export class StreamServer extends EventEmitter {
       throw new Error("Server is already running");
     }
 
+    // stop() removes the protocol listeners so a disposed server does not
+    // retain the WebSocket client. Reinstall them for an intentional restart.
+    if (!this.eventRemover || !this.audioEventRemover) {
+      this.setupWebSocketListener();
+    }
+
     await new Promise<void>((resolve, reject) => {
       this.server = net.createServer();
 
@@ -2091,6 +2097,11 @@ export class StreamServer extends EventEmitter {
   /** Start a new P2P session whose metadata must be freshly confirmed. */
   private beginMetadataSession(): void {
     this.metadataGeneration++;
+    // Audio is session-scoped just like codec metadata. A camera may deliver
+    // AAC in one P2P session and no audio in the next, so carrying this flag
+    // forward would advertise and configure a non-existent track.
+    this.deliversAudio = undefined;
+    this.audioMetadata = null;
   }
 
   /** Whether metadata has been confirmed by video data for this P2P session. */

--- a/packages/eufy-stream-server/src/stream-server.ts
+++ b/packages/eufy-stream-server/src/stream-server.ts
@@ -374,6 +374,8 @@ export class StreamServer extends EventEmitter {
     timer: ReturnType<typeof setTimeout>;
   };
   private nextWarmLeaseId = 0;
+  /** Serializes stop → release → reacquire when a slot changes priority. */
+  private streamSlotTransition?: Promise<void>;
   /**
    * Set when a higher-priority camera on the same HomeBase preempted us. While
    * true we stay down (don't re-start) despite lingering consumers and don't
@@ -527,9 +529,6 @@ export class StreamServer extends EventEmitter {
    */
   holdWarmLease(ms: number = 60000): void {
     if (this.warmLease || this.getRealConsumerCount() > 0) return;
-    // A previous metadata bootstrap may have acquired a live grant. It must
-    // not leak into the warm period: release it before the background retry.
-    if (this.streamLeasePriority === "live") this.releaseStreamSlot();
     const id = ++this.nextWarmLeaseId;
     this.metadataBootstrapConsumers++;
     this.warmLease = {
@@ -537,12 +536,67 @@ export class StreamServer extends EventEmitter {
       timer: setTimeout(() => this.endWarmLease("expired", false, id), ms),
     };
     this.warmLease.timer.unref?.();
-    this.livestreamIntendedState = true;
     this.lastClientActivity = Date.now();
     this.startActivityMonitoring();
-    void this.ensureLivestreamState().catch((error) =>
-      this.logger.warn(`Failed to start warm lease: ${error}`),
-    );
+    void this.activateWarmLease(id);
+  }
+
+  /** Stop our P2P stream before relinquishing a station grant. */
+  private async stopUpstreamBeforeReleasingStreamSlot(): Promise<void> {
+    if (!this.streamLease) return;
+    try {
+      await this.options.wsClient.commands
+        .device(this.options.serialNumber)
+        .stopLivestream();
+    } catch (error: any) {
+      if (
+        !String(error?.message || error).includes(
+          "device_livestream_not_running",
+        )
+      ) {
+        throw error;
+      }
+    }
+    this.setLivestreamActual(false);
+    this.lastVideoDataAt = 0;
+    this.livestreamSessionStartedAt = 0;
+    this.releaseStreamSlot();
+  }
+
+  private async activateWarmLease(id: number): Promise<void> {
+    const warmLease = this.warmLease;
+    if (!warmLease || warmLease.id !== id) return;
+
+    // A live lease may let a sibling's `whenReady` resolve immediately when
+    // released. Stop the upstream first; only then is a background attempt
+    // allowed to yield that station slot.
+    if (this.streamLeasePriority === "live") {
+      this.livestreamIntendedState = false;
+      try {
+        await this.stopUpstreamBeforeReleasingStreamSlot();
+      } catch (error) {
+        this.logger.warn(
+          `Failed to stop upstream before warm handoff; retaining live slot: ${error}`,
+        );
+        return;
+      }
+    }
+
+    if (
+      !this.warmLease ||
+      this.warmLease.id !== id ||
+      this.getRealConsumerCount() > 0 ||
+      this.slotRevoked
+    ) {
+      return;
+    }
+    this.consecutiveNoDataStarts = 0;
+    this.livestreamIntendedState = true;
+    try {
+      await this.ensureLivestreamState();
+    } catch (error) {
+      this.logger.warn(`Failed to start warm lease: ${error}`);
+    }
   }
 
   private endWarmLease(
@@ -562,10 +616,34 @@ export class StreamServer extends EventEmitter {
     this.metadataBootstrapConsumers--;
 
     if (replacedByRealConsumer && this.getRealConsumerCount() > 0) {
-      // Never let a later warm expiry release the new live grant. Reacquire it
-      // at live priority; release the background grant before asking for it.
-      if (this.streamLeasePriority === "background") this.releaseStreamSlot();
-      void this.updateLivestreamStateForMuxerClients();
+      // Never let a later warm expiry release the new live grant. The same
+      // stop-before-release ordering also applies when promoting a background
+      // stream to live: a sibling may otherwise start between the release and
+      // our live reacquisition while our P2P stream still owns the HomeBase.
+      if (this.streamLeasePriority === "background") {
+        this.livestreamIntendedState = false;
+        const transition = this.stopUpstreamBeforeReleasingStreamSlot()
+          .then(async () => {
+            if (this.getRealConsumerCount() > 0 && !this.slotRevoked) {
+              this.consecutiveNoDataStarts = 0;
+              this.livestreamIntendedState = true;
+              await this.ensureLivestreamState();
+            }
+          })
+          .catch((error) => {
+            this.logger.warn(
+              `Failed to promote warm slot to live safely: ${error}`,
+            );
+          });
+        this.streamSlotTransition = transition;
+        void transition.finally(() => {
+          if (this.streamSlotTransition === transition) {
+            this.streamSlotTransition = undefined;
+          }
+        });
+      } else {
+        void this.updateLivestreamStateForMuxerClients();
+      }
       return;
     }
 
@@ -1139,7 +1217,10 @@ export class StreamServer extends EventEmitter {
             this.streamLease?.active &&
             this.streamLeasePriority !== priority
           ) {
-            this.releaseStreamSlot();
+            this.livestreamIntendedState = false;
+            await this.stopUpstreamBeforeReleasingStreamSlot();
+            if (this.slotRevoked) break;
+            this.livestreamIntendedState = true;
           }
           if (!this.streamLease?.active) {
             const lease = this.options.acquireStreamSlot(priority, () =>
@@ -1150,6 +1231,9 @@ export class StreamServer extends EventEmitter {
                 `⛔ HomeBase stream slot busy — deferring ${priority} start`,
               );
               this.livestreamIntendedState = false;
+              if (priority === "background" && this.warmLease) {
+                this.endWarmLease("background slot denied", false);
+              }
               break;
             }
             this.logger.info(`🎟️  Acquired HomeBase stream slot (${priority})`);
@@ -1576,6 +1660,10 @@ export class StreamServer extends EventEmitter {
   }
 
   private async updateLivestreamStateForMuxerClients(): Promise<void> {
+    if (this.streamSlotTransition) {
+      await this.streamSlotTransition;
+      return;
+    }
     const totalConsumers = this.getTotalConsumers();
 
     // A consumer is attaching (or detaching). If we were lingering after a

--- a/packages/eufy-stream-server/src/stream-server.ts
+++ b/packages/eufy-stream-server/src/stream-server.ts
@@ -143,6 +143,10 @@ export class StreamServer extends EventEmitter {
     { muxer: JMuxer; duplex: Duplex }
   >();
   private pendingMuxerSockets = new Set<net.Socket>();
+  private pendingMetadataWaitAbortControllers = new Map<
+    net.Socket,
+    AbortController
+  >();
 
   /**
    * Count every "thing currently waiting on or consuming the livestream":
@@ -1269,6 +1273,10 @@ export class StreamServer extends EventEmitter {
     // socket disappears before the first frame arrives, abort that waiter
     // immediately instead of retaining it until the 60s metadata timeout.
     const metadataWaitAbortController = new AbortController();
+    this.pendingMetadataWaitAbortControllers.set(
+      socket,
+      metadataWaitAbortController,
+    );
     const cancelMetadataWait = () => metadataWaitAbortController.abort();
     socket.once("close", cancelMetadataWait);
     socket.once("error", cancelMetadataWait);
@@ -1304,6 +1312,7 @@ export class StreamServer extends EventEmitter {
     } finally {
       socket.removeListener("close", cancelMetadataWait);
       socket.removeListener("error", cancelMetadataWait);
+      this.pendingMetadataWaitAbortControllers.delete(socket);
     }
 
     // Socket may have given up while we waited.
@@ -1562,6 +1571,13 @@ export class StreamServer extends EventEmitter {
     this.muxerStreams.clear();
 
     // Also close any muxer clients still waiting for first-frame metadata
+    // and synchronously cancel their waits before `stop()` resolves. Socket
+    // close events are asynchronous, so relying on them alone leaks waiters
+    // across the shutdown boundary.
+    for (const controller of this.pendingMetadataWaitAbortControllers.values()) {
+      controller.abort();
+    }
+    this.pendingMetadataWaitAbortControllers.clear();
     for (const socket of this.pendingMuxerSockets) {
       if (!socket.destroyed) socket.destroy();
     }

--- a/packages/eufy-stream-server/src/stream-server.ts
+++ b/packages/eufy-stream-server/src/stream-server.ts
@@ -627,7 +627,7 @@ export class StreamServer extends EventEmitter {
             if (this.getRealConsumerCount() > 0 && !this.slotRevoked) {
               this.consecutiveNoDataStarts = 0;
               this.livestreamIntendedState = true;
-              await this.ensureLivestreamState();
+              await this.ensureLivestreamState(true);
             }
           })
           .catch((error) => {
@@ -1082,8 +1082,6 @@ export class StreamServer extends EventEmitter {
     }
 
     this.livestreamIntendedState = false;
-    this.setLivestreamActual(false);
-    this.releaseStreamSlot();
     this.consecutiveNoDataStarts = 0;
     this.lastVideoDataAt = 0;
     this.livestreamSessionStartedAt = 0;
@@ -1091,6 +1089,27 @@ export class StreamServer extends EventEmitter {
     if (this.startStopTimeout) {
       clearTimeout(this.startStopTimeout);
       this.startStopTimeout = undefined;
+    }
+
+    // A recycle can begin as soon as this event is emitted. Keep the station
+    // grant until P2P stop completes, and make post-recycle rearming wait for
+    // that ordered teardown so a sibling cannot overlap our stream.
+    if (this.streamLease) {
+      const transition = this.stopUpstreamBeforeReleasingStreamSlot().catch(
+        (error) => {
+          this.logger.warn(
+            `Failed to stop wedged upstream before releasing stream slot: ${error}`,
+          );
+        },
+      );
+      this.streamSlotTransition = transition;
+      void transition.finally(() => {
+        if (this.streamSlotTransition === transition) {
+          this.streamSlotTransition = undefined;
+        }
+      });
+    } else {
+      this.setLivestreamActual(false);
     }
 
     this.emit("upstreamWedged", {
@@ -1173,7 +1192,12 @@ export class StreamServer extends EventEmitter {
   /**
    * Ensure the livestream is in the correct state with retry logic
    */
-  private async ensureLivestreamState(): Promise<void> {
+  private async ensureLivestreamState(
+    skipSlotTransition: boolean = false,
+  ): Promise<void> {
+    if (!skipSlotTransition && this.streamSlotTransition) {
+      await this.streamSlotTransition;
+    }
     // Clear any existing timeout
     if (this.startStopTimeout) {
       clearTimeout(this.startStopTimeout);

--- a/packages/eufy-stream-server/src/stream-server.ts
+++ b/packages/eufy-stream-server/src/stream-server.ts
@@ -1265,6 +1265,14 @@ export class StreamServer extends EventEmitter {
     socket.on("close", pendingCleanup);
     socket.on("error", pendingCleanup);
 
+    // A pending muxer client owns a metadata waiter. If its downstream
+    // socket disappears before the first frame arrives, abort that waiter
+    // immediately instead of retaining it until the 60s metadata timeout.
+    const metadataWaitAbortController = new AbortController();
+    const cancelMetadataWait = () => metadataWaitAbortController.abort();
+    socket.once("close", cancelMetadataWait);
+    socket.once("error", cancelMetadataWait);
+
     // Kick off the upstream livestream (no-op if already running).
     this.updateLivestreamStateForMuxerClients();
 
@@ -1282,13 +1290,20 @@ export class StreamServer extends EventEmitter {
     try {
       // 60s — battery cameras (T8170 S340 sleep mode, T86P2 4G LTE cold-start)
       // can take 30–45s to deliver their first IDR after startLivestream.
-      const metadata = await this.waitForVideoMetadata(60000);
+      const metadata = await this.waitForVideoMetadata(60000, {
+        signal: metadataWaitAbortController.signal,
+      });
       const c = metadata.videoCodec.toUpperCase();
       videoCodec = c === "H265" || c === "HEVC" ? "H265" : "H264";
     } catch (e) {
-      this.logger.warn(
-        `Muxer client: timed out waiting for video metadata, falling back to hinted codec ${videoCodec}. ${e}`,
-      );
+      if (!metadataWaitAbortController.signal.aborted) {
+        this.logger.warn(
+          `Muxer client: timed out waiting for video metadata, falling back to hinted codec ${videoCodec}. ${e}`,
+        );
+      }
+    } finally {
+      socket.removeListener("close", cancelMetadataWait);
+      socket.removeListener("error", cancelMetadataWait);
     }
 
     // Socket may have given up while we waited.

--- a/packages/eufy-stream-server/src/stream-server.ts
+++ b/packages/eufy-stream-server/src/stream-server.ts
@@ -90,6 +90,11 @@ export interface StationSlotLease {
   markDelivering(): void;
 }
 
+interface MetadataWaiter {
+  resolve(metadata: VideoMetadata): void;
+  reject(error: Error): void;
+}
+
 /**
  * Simple TCP streaming server for raw H.264 video data
  *
@@ -294,7 +299,14 @@ export class StreamServer extends EventEmitter {
    * replaces this with full real metadata.
    */
   private hintedVideoCodec?: "H264" | "H265";
-  private metadataReceived = false;
+  /**
+   * Metadata is only authoritative for the P2P session that delivered it.
+   * Keep the last record as a compatibility hint, but require every new
+   * session to verify it with a fresh video event before consumers trust it.
+   */
+  private metadataGeneration = 0;
+  private metadataVerifiedGeneration = -1;
+  private metadataWaiters: MetadataWaiter[] = [];
 
   // Audio metadata from first audio frame
   private audioMetadata: AudioMetadata | null = null;
@@ -647,19 +659,26 @@ export class StreamServer extends EventEmitter {
           }
         }
 
-        // Capture video metadata from first frame
-        if (!this.metadataReceived && event.metadata) {
+        // Capture metadata once for each P2P session. The previous session's
+        // record remains available as a hint, but cannot verify this one.
+        if (
+          event.metadata &&
+          !this.isMetadataVerifiedForCurrentSession()
+        ) {
           this.videoMetadata = {
             videoCodec: event.metadata.videoCodec,
             videoFPS: event.metadata.videoFPS,
             videoWidth: event.metadata.videoWidth,
             videoHeight: event.metadata.videoHeight,
           };
-          this.metadataReceived = true;
+          this.metadataVerifiedGeneration = this.metadataGeneration;
           this.logger.info(
             `📐 Captured video metadata: ${this.videoMetadata.videoWidth}x${this.videoMetadata.videoHeight} @ ${this.videoMetadata.videoFPS}fps, codec: ${this.videoMetadata.videoCodec}`,
           );
           this.emit("metadataReceived", this.videoMetadata);
+          for (const waiter of this.metadataWaiters.splice(0)) {
+            waiter.resolve(this.videoMetadata);
+          }
         }
 
         // Mark livestream as actually running when we receive data
@@ -1063,6 +1082,7 @@ export class StreamServer extends EventEmitter {
           this.logger.info(
             `🎥 Starting livestream (attempt ${attempt}/${maxRetries}, consecutive-no-data=${this.consecutiveNoDataStarts}/${this.MAX_NO_DATA_STARTS})`,
           );
+          this.beginMetadataSession();
           await this.options.wsClient.commands
             .device(this.options.serialNumber)
             .startLivestream();
@@ -1091,6 +1111,7 @@ export class StreamServer extends EventEmitter {
           // cold-start counter increment to catch it the other way).
           if (this.livestreamSessionStartedAt === 0) {
             this.livestreamSessionStartedAt = Date.now();
+            this.beginMetadataSession();
             this.logger.info(
               "📡 Bropat reports livestream already active — anchoring session for wedge watchdog",
             );
@@ -1789,15 +1810,30 @@ export class StreamServer extends EventEmitter {
     return null;
   }
 
+  /** Start a new P2P session whose metadata must be freshly confirmed. */
+  private beginMetadataSession(): void {
+    this.metadataGeneration++;
+  }
+
+  /** Whether metadata has been confirmed by video data for this P2P session. */
+  isMetadataVerifiedForCurrentSession(): boolean {
+    return this.metadataVerifiedGeneration === this.metadataGeneration;
+  }
+
   /**
    * Wait for video metadata to be received
    */
   async waitForVideoMetadata(
     timeoutMs: number = 10000,
+    options?: { signal?: AbortSignal },
   ): Promise<VideoMetadata> {
-    if (this.videoMetadata) {
-      this.logger.debug("Video metadata already available");
+    if (this.videoMetadata && this.isMetadataVerifiedForCurrentSession()) {
+      this.logger.debug("Video metadata already verified for this session");
       return this.videoMetadata;
+    }
+
+    if (options?.signal?.aborted) {
+      throw new Error("Video metadata wait cancelled");
     }
 
     this.logger.debug(
@@ -1805,20 +1841,40 @@ export class StreamServer extends EventEmitter {
     );
 
     return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
+      let settled = false;
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      const signal = options?.signal;
+      const waiter: MetadataWaiter = {
+        resolve: (metadata) => settle(() => resolve(metadata)),
+        reject: (error) => settle(() => reject(error)),
+      };
+      const removeWaiter = () => {
+        const index = this.metadataWaiters.indexOf(waiter);
+        if (index !== -1) this.metadataWaiters.splice(index, 1);
+        if (timeout) clearTimeout(timeout);
+        signal?.removeEventListener("abort", onAbort);
+      };
+      const settle = (complete: () => void) => {
+        if (settled) return;
+        settled = true;
+        removeWaiter();
+        complete();
+      };
+      const onAbort = () => {
+        waiter.reject(new Error("Video metadata wait cancelled"));
+      };
+
+      this.metadataWaiters.push(waiter);
+      timeout = setTimeout(() => {
         this.logger.warn(
           `Timeout waiting for video metadata (${timeoutMs}ms). Livestream state: ${this.livestreamActualState}, intended: ${this.livestreamIntendedState}`,
         );
-        reject(
+        waiter.reject(
           new Error(`Timeout waiting for video metadata (${timeoutMs}ms)`),
         );
       }, timeoutMs);
-
-      this.once("metadataReceived", (metadata) => {
-        clearTimeout(timeout);
-        this.logger.debug("Video metadata received successfully");
-        resolve(metadata);
-      });
+      timeout.unref?.();
+      signal?.addEventListener("abort", onAbort, { once: true });
     });
   }
 

--- a/packages/eufy-stream-server/src/stream-server.ts
+++ b/packages/eufy-stream-server/src/stream-server.ts
@@ -95,6 +95,12 @@ interface MetadataWaiter {
   reject(error: Error): void;
 }
 
+export interface MetadataBootstrapWaiter {
+  promise: Promise<VideoMetadata>;
+  release(): void;
+  cancel(): void;
+}
+
 /**
  * Simple TCP streaming server for raw H.264 video data
  *
@@ -147,6 +153,9 @@ export class StreamServer extends EventEmitter {
     net.Socket,
     AbortController
   >();
+  /** Consumers which need the first frame's metadata, but have no TCP socket. */
+  private metadataBootstrapConsumers = 0;
+  private nextConsumerAttachedCallbacks = new Set<() => void>();
 
   /**
    * Count every "thing currently waiting on or consuming the livestream":
@@ -169,8 +178,24 @@ export class StreamServer extends EventEmitter {
       this.connectionManager.getActiveConnectionCount() +
       this.muxerStreams.size +
       this.pendingMuxerSockets.size +
-      this.snapshotResolvers.length
+      this.snapshotResolvers.length +
+      this.metadataBootstrapConsumers
     );
+  }
+
+  /** TCP/muxer/snapshot consumers, excluding metadata and warm bootstrap holds. */
+  private getRealConsumerCount(): number {
+    return this.getTotalConsumers() - this.metadataBootstrapConsumers;
+  }
+
+  private getDesiredStreamSlotPriority(): "live" | "background" {
+    if (this.warmLease) return "background";
+    const liveConsumers =
+      this.connectionManager.getActiveConnectionCount() +
+      this.muxerStreams.size +
+      this.pendingMuxerSockets.size +
+      this.metadataBootstrapConsumers;
+    return liveConsumers > 0 ? "live" : "background";
   }
   private connectionManager: ConnectionManager;
   private h264Parser: H264Parser;
@@ -342,6 +367,13 @@ export class StreamServer extends EventEmitter {
    * one streaming on its station; released when the stream stops.
    */
   private streamLease: StationSlotLease | null = null;
+  private streamLeasePriority: "live" | "background" | null = null;
+  /** A preemptible, no-viewer window retained after a cold metadata attempt. */
+  private warmLease?: {
+    id: number;
+    timer: ReturnType<typeof setTimeout>;
+  };
+  private nextWarmLeaseId = 0;
   /**
    * Set when a higher-priority camera on the same HomeBase preempted us. While
    * true we stay down (don't re-start) despite lingering consumers and don't
@@ -443,6 +475,7 @@ export class StreamServer extends EventEmitter {
     this.connectionManager.on(
       "clientConnected",
       async (connectionId, connectionInfo) => {
+        this.notifyNextConsumerAttached();
         this.logger.info(
           `Client connected: ${connectionId} from ${connectionInfo.remoteAddress}:${connectionInfo.remotePort}`,
         );
@@ -467,6 +500,81 @@ export class StreamServer extends EventEmitter {
       // Stop livestream only if no consumers remain.
       await this.updateLivestreamStateForMuxerClients();
     });
+  }
+
+  /** Invoke callbacks waiting to hand a bootstrap stream to its first viewer. */
+  private notifyNextConsumerAttached(): void {
+    // A real viewer replaces a preemptible warm bootstrap. Drop its background
+    // grant so the normal live path reacquires the station slot at live
+    // priority; the timer is generation guarded and can no longer tear down
+    // the viewer's replacement lease.
+    if (this.warmLease) this.endWarmLease("consumer attached", true);
+    const callbacks = Array.from(this.nextConsumerAttachedCallbacks);
+    this.nextConsumerAttachedCallbacks.clear();
+    for (const callback of callbacks) callback();
+  }
+
+  /** Register a one-shot notification for the next raw or muxed consumer. */
+  onNextConsumerAttached(callback: () => void): () => void {
+    this.nextConsumerAttachedCallbacks.add(callback);
+    return () => this.nextConsumerAttachedCallbacks.delete(callback);
+  }
+
+  /**
+   * Retain one preemptible background consumer after an unsuccessful cold
+   * start. It belongs to the ordinary consumer accounting so recycle recovery
+   * can re-arm it, but never competes with a real viewer for a live slot.
+   */
+  holdWarmLease(ms: number = 60000): void {
+    if (this.warmLease || this.getRealConsumerCount() > 0) return;
+    // A previous metadata bootstrap may have acquired a live grant. It must
+    // not leak into the warm period: release it before the background retry.
+    if (this.streamLeasePriority === "live") this.releaseStreamSlot();
+    const id = ++this.nextWarmLeaseId;
+    this.metadataBootstrapConsumers++;
+    this.warmLease = {
+      id,
+      timer: setTimeout(() => this.endWarmLease("expired", false, id), ms),
+    };
+    this.warmLease.timer.unref?.();
+    this.livestreamIntendedState = true;
+    this.lastClientActivity = Date.now();
+    this.startActivityMonitoring();
+    void this.ensureLivestreamState().catch((error) =>
+      this.logger.warn(`Failed to start warm lease: ${error}`),
+    );
+  }
+
+  private endWarmLease(
+    reason: string,
+    replacedByRealConsumer: boolean,
+    expectedId?: number,
+  ): void {
+    const warmLease = this.warmLease;
+    if (
+      !warmLease ||
+      (expectedId !== undefined && warmLease.id !== expectedId)
+    ) {
+      return;
+    }
+    clearTimeout(warmLease.timer);
+    this.warmLease = undefined;
+    this.metadataBootstrapConsumers--;
+
+    if (replacedByRealConsumer && this.getRealConsumerCount() > 0) {
+      // Never let a later warm expiry release the new live grant. Reacquire it
+      // at live priority; release the background grant before asking for it.
+      if (this.streamLeasePriority === "background") this.releaseStreamSlot();
+      void this.updateLivestreamStateForMuxerClients();
+      return;
+    }
+
+    // Safety ordering matters to station handoff: stop the P2P session before
+    // freeing its background slot, so a sibling's whenReady cannot overlap it.
+    this.livestreamIntendedState = false;
+    void this.ensureLivestreamState().catch((error) =>
+      this.logger.warn(`Failed to end warm lease (${reason}): ${error}`),
+    );
   }
 
   /**
@@ -665,10 +773,7 @@ export class StreamServer extends EventEmitter {
 
         // Capture metadata once for each P2P session. The previous session's
         // record remains available as a hint, but cannot verify this one.
-        if (
-          event.metadata &&
-          !this.isMetadataVerifiedForCurrentSession()
-        ) {
+        if (event.metadata && !this.isMetadataVerifiedForCurrentSession()) {
           this.videoMetadata = {
             videoCodec: event.metadata.videoCodec,
             videoFPS: event.metadata.videoFPS,
@@ -686,6 +791,7 @@ export class StreamServer extends EventEmitter {
         }
 
         // Mark livestream as actually running when we receive data
+        if (this.warmLease) this.endWarmLease("first live frame", false);
         if (!this.livestreamActualState) {
           this.setLivestreamActual(true);
           this.consecutiveNoDataStarts = 0;
@@ -930,6 +1036,7 @@ export class StreamServer extends EventEmitter {
       this.streamLease.release();
       this.streamLease = null;
     }
+    this.streamLeasePriority = null;
   }
 
   /**
@@ -944,6 +1051,7 @@ export class StreamServer extends EventEmitter {
       "↩️  HomeBase stream slot revoked by another camera — yielding",
     );
     this.slotRevoked = true;
+    if (this.warmLease) this.endWarmLease("slot revoked", false);
     this.livestreamIntendedState = false;
     // Stop our P2P livestream FIRST, then release the slot — do NOT release
     // synchronously here. The preemptor's `whenReady` is gated on our release,
@@ -1016,6 +1124,42 @@ export class StreamServer extends EventEmitter {
           );
         }
 
+        // Maintain the station grant independently of bropat's status. A
+        // real consumer can take over a background warm stream while bropat
+        // still reports it running; it nevertheless needs a live-priority
+        // lease before that stream is allowed to continue.
+        if (
+          this.livestreamIntendedState &&
+          !this.slotRevoked &&
+          !this.recycleInFlight &&
+          this.options.acquireStreamSlot
+        ) {
+          const priority = this.getDesiredStreamSlotPriority();
+          if (
+            this.streamLease?.active &&
+            this.streamLeasePriority !== priority
+          ) {
+            this.releaseStreamSlot();
+          }
+          if (!this.streamLease?.active) {
+            const lease = this.options.acquireStreamSlot(priority, () =>
+              this.handleSlotRevoked(),
+            );
+            if (!lease) {
+              this.logger.info(
+                `⛔ HomeBase stream slot busy — deferring ${priority} start`,
+              );
+              this.livestreamIntendedState = false;
+              break;
+            }
+            this.logger.info(`🎟️  Acquired HomeBase stream slot (${priority})`);
+            this.streamLease = lease;
+            this.streamLeasePriority = priority;
+            await lease.whenReady;
+            if (!this.livestreamIntendedState || this.slotRevoked) break;
+          }
+        }
+
         if (this.livestreamIntendedState && !actualStreamingStatus) {
           // Defer if a station P2P recycle is in flight — startLivestream
           // sent during the recovery window typically lands on a station
@@ -1047,37 +1191,6 @@ export class StreamServer extends EventEmitter {
               "⏸️  Slot revoked by another camera on this HomeBase — not starting until consumers drain",
             );
             break;
-          }
-
-          // Acquire the shared HomeBase stream slot before starting. Only the
-          // slot holder ever issues startLivestream, so cameras never stampede
-          // the one-stream-at-a-time HomeBase.
-          if (this.options.acquireStreamSlot && !this.streamLease?.active) {
-            const priority =
-              this.getTotalConsumers() > 0 ? "live" : "background";
-            const lease = this.options.acquireStreamSlot(priority, () =>
-              this.handleSlotRevoked(),
-            );
-            if (!lease) {
-              // Background (thumbnail refresh) denied — the slot is busy with a
-              // viewer/recorder. Don't wake; abandon this attempt quietly.
-              this.logger.info(
-                `⛔ HomeBase stream slot busy — deferring ${priority} start`,
-              );
-              this.livestreamIntendedState = false;
-              break;
-            }
-            this.logger.info(`🎟️  Acquired HomeBase stream slot (${priority})`);
-            this.streamLease = lease;
-            // If we preempted another camera, wait for it to step off the
-            // shared HomeBase slot before starting, so the two don't overlap
-            // (which causes mutual P2P starvation and audio bleeding into the
-            // wrong muxer). Resolves immediately when nothing was preempted.
-            await lease.whenReady;
-            // Bail if we were ourselves preempted/torn down while waiting.
-            if (!this.livestreamIntendedState || this.slotRevoked) {
-              break;
-            }
           }
 
           // Need to start livestream
@@ -1145,6 +1258,7 @@ export class StreamServer extends EventEmitter {
           // leaving `livestreamActualState` stuck true would leak a stale
           // "active" entry into the cross-camera station registry.
           this.setLivestreamActual(false);
+          this.releaseStreamSlot();
           this.logger.debug("Livestream already stopped as desired");
         }
 
@@ -1262,6 +1376,7 @@ export class StreamServer extends EventEmitter {
     // `updateLivestreamStateForMuxerClients` counts both pending and active
     // muxers as consumers.
     this.pendingMuxerSockets.add(socket);
+    this.notifyNextConsumerAttached();
 
     const pendingCleanup = () => {
       this.pendingMuxerSockets.delete(socket);
@@ -1486,6 +1601,14 @@ export class StreamServer extends EventEmitter {
       this.lastClientActivity = Date.now();
       this.startActivityMonitoring();
       await this.ensureLivestreamState();
+    } else if (
+      totalConsumers > 0 &&
+      this.livestreamIntendedState &&
+      !this.slotRevoked &&
+      (!this.streamLease?.active ||
+        this.streamLeasePriority !== this.getDesiredStreamSlotPriority())
+    ) {
+      await this.ensureLivestreamState();
     }
     // Intentionally *not* stopping the livestream the moment consumer
     // count drops to 0. Scrypted's Rebroadcast plugin cycles its muxer
@@ -1527,6 +1650,11 @@ export class StreamServer extends EventEmitter {
       this.startStopTimeout = undefined;
     }
     this.cancelPostSnapshotLinger("server stopping");
+    if (this.warmLease) {
+      clearTimeout(this.warmLease.timer);
+      this.warmLease = undefined;
+      this.metadataBootstrapConsumers--;
+    }
 
     // Stop activity monitoring
     this.stopActivityMonitoring();
@@ -1841,6 +1969,13 @@ export class StreamServer extends EventEmitter {
     return null;
   }
 
+  /** Audio capability as observed by the live stream. */
+  getAudioStatus(): "unknown" | "aac" | "none" {
+    if (this.deliversAudio === true) return "aac";
+    if (this.deliversAudio === false) return "none";
+    return "unknown";
+  }
+
   /** Start a new P2P session whose metadata must be freshly confirmed. */
   private beginMetadataSession(): void {
     this.metadataGeneration++;
@@ -1907,6 +2042,53 @@ export class StreamServer extends EventEmitter {
       timeout.unref?.();
       signal?.addEventListener("abort", onAbort, { once: true });
     });
+  }
+
+  /**
+   * Reserve an upstream consumer while a caller waits for freshly-confirmed
+   * video metadata. This is intentionally independent of TCP clients: codec
+   * selection has to wake the camera before Rebroadcast attaches its socket.
+   */
+  acquireMetadataWaiter(timeoutMs: number = 10000): MetadataBootstrapWaiter {
+    const controller = new AbortController();
+    let held = true;
+    let settled = false;
+    this.metadataBootstrapConsumers++;
+    void this.updateLivestreamStateForMuxerClients();
+
+    const release = () => {
+      if (!held) return;
+      held = false;
+      this.metadataBootstrapConsumers--;
+      if (!settled) controller.abort();
+      if (this.getTotalConsumers() === 0 && !this.warmLease) {
+        // A cancelled bootstrap must reclaim its live station lease rather
+        // than leaving a P2P session held until the activity watchdog fires.
+        this.livestreamIntendedState = false;
+        void this.ensureLivestreamState();
+      } else {
+        void this.updateLivestreamStateForMuxerClients();
+      }
+    };
+
+    const promise = this.waitForVideoMetadata(timeoutMs, {
+      signal: controller.signal,
+    }).then(
+      (metadata) => {
+        settled = true;
+        return metadata;
+      },
+      (error) => {
+        settled = true;
+        if (/timeout/i.test(String(error?.message || error))) {
+          this.holdWarmLease();
+        }
+        release();
+        throw error;
+      },
+    );
+
+    return { promise, release, cancel: release };
   }
 
   /**

--- a/packages/eufy-stream-server/src/thermal-governor.ts
+++ b/packages/eufy-stream-server/src/thermal-governor.ts
@@ -1,0 +1,191 @@
+/**
+ * A temperature source used to protect the host from admitting more
+ * compatibility encoders while it is too hot. Returning `undefined` means
+ * the platform does not expose a usable temperature reading.
+ */
+export type TemperatureReader = () =>
+  | number
+  | undefined
+  | null
+  | Promise<number | undefined | null>;
+
+export type ThermalGovernorReason =
+  | "not-sampled"
+  | "unsupported"
+  | "read-error"
+  | "normal-temperature"
+  | "critical-temperature"
+  | "above-recovery-temperature"
+  | "recovered";
+
+export interface ThermalGovernorStatus {
+  /** Whether new compatibility encoder admissions should be denied. */
+  throttled: boolean;
+  /** Why the governor is allowing or denying a new admission. */
+  reason: ThermalGovernorReason;
+  /** Most recent usable temperature reading, in degrees Celsius. */
+  temperatureC?: number;
+}
+
+export interface ThermalGovernorOptions {
+  /** Optional host temperature source. Without one the governor is inert. */
+  temperatureReader?: TemperatureReader;
+  /** Temperature at which new compatibility encoders are denied. */
+  criticalTemperatureC?: number;
+  /** Temperature at which compatibility encoder admission resumes. */
+  recoveryTemperatureC?: number;
+  /** Minimum time between admission-triggered temperature samples. */
+  samplingIntervalMs?: number;
+  /** Injectable clock for deterministic sampling tests. */
+  now?: () => number;
+}
+
+const DEFAULT_CRITICAL_TEMPERATURE_C = 85;
+const DEFAULT_RECOVERY_TEMPERATURE_C = 75;
+const DEFAULT_SAMPLING_INTERVAL_MS = 30_000;
+
+/**
+ * Applies a hysteresis-based thermal admission gate to compatibility encoders.
+ *
+ * It only decides whether a *new* compatibility encoder may be admitted. It
+ * deliberately has no reference to existing encoders and therefore can never
+ * terminate an encoder that is already running.
+ */
+export class ThermalGovernor {
+  private readonly temperatureReader?: TemperatureReader;
+  private readonly criticalTemperatureC: number;
+  private readonly recoveryTemperatureC: number;
+  private readonly samplingIntervalMs: number;
+  private readonly now: () => number;
+  private status: ThermalGovernorStatus = {
+    throttled: false,
+    reason: "not-sampled",
+  };
+  private lastSampleAt?: number;
+  private sampleInFlight?: Promise<ThermalGovernorStatus>;
+
+  constructor(options: ThermalGovernorOptions = {}) {
+    this.temperatureReader = options.temperatureReader;
+    this.criticalTemperatureC =
+      options.criticalTemperatureC ?? DEFAULT_CRITICAL_TEMPERATURE_C;
+    this.recoveryTemperatureC =
+      options.recoveryTemperatureC ?? DEFAULT_RECOVERY_TEMPERATURE_C;
+    this.samplingIntervalMs =
+      options.samplingIntervalMs ?? DEFAULT_SAMPLING_INTERVAL_MS;
+    this.now = options.now ?? Date.now;
+
+    this.validateConfiguration();
+  }
+
+  /** Force an immediate sample, irrespective of the sampling interval. */
+  public refresh(): Promise<ThermalGovernorStatus> {
+    return this.sample();
+  }
+
+  /**
+   * Sample if due and return whether a new compatibility encoder may start.
+   * Concurrent callers share one temperature read and observe the same state.
+   */
+  public async checkCompatibilityEncoderAdmission(): Promise<boolean> {
+    if (this.isSamplingDue()) {
+      await this.sample();
+    }
+
+    return this.canAdmitCompatibilityEncoder();
+  }
+
+  /** Return the admission decision from the latest sampled state. */
+  public canAdmitCompatibilityEncoder(): boolean {
+    return !this.status.throttled;
+  }
+
+  /** Return a copy so callers cannot mutate the governor's state. */
+  public getStatus(): ThermalGovernorStatus {
+    return { ...this.status };
+  }
+
+  private isSamplingDue(): boolean {
+    return (
+      this.lastSampleAt === undefined ||
+      this.now() - this.lastSampleAt >= this.samplingIntervalMs
+    );
+  }
+
+  private sample(): Promise<ThermalGovernorStatus> {
+    if (this.sampleInFlight) {
+      return this.sampleInFlight;
+    }
+
+    this.sampleInFlight = this.readTemperature().finally(() => {
+      this.sampleInFlight = undefined;
+    });
+    return this.sampleInFlight;
+  }
+
+  private async readTemperature(): Promise<ThermalGovernorStatus> {
+    this.lastSampleAt = this.now();
+
+    if (!this.temperatureReader) {
+      return this.setInertStatus("unsupported");
+    }
+
+    try {
+      const temperatureC = await this.temperatureReader();
+      if (temperatureC === undefined || temperatureC === null) {
+        return this.setInertStatus("unsupported");
+      }
+      if (!Number.isFinite(temperatureC)) {
+        return this.setInertStatus("read-error");
+      }
+
+      if (this.status.throttled) {
+        this.status =
+          temperatureC <= this.recoveryTemperatureC
+            ? { throttled: false, reason: "recovered", temperatureC }
+            : {
+                throttled: true,
+                reason: "above-recovery-temperature",
+                temperatureC,
+              };
+      } else {
+        this.status =
+          temperatureC >= this.criticalTemperatureC
+            ? { throttled: true, reason: "critical-temperature", temperatureC }
+            : { throttled: false, reason: "normal-temperature", temperatureC };
+      }
+    } catch {
+      return this.setInertStatus("read-error");
+    }
+
+    return this.getStatus();
+  }
+
+  private setInertStatus(
+    reason: Extract<ThermalGovernorReason, "unsupported" | "read-error">,
+  ): ThermalGovernorStatus {
+    this.status = { throttled: false, reason };
+    return this.getStatus();
+  }
+
+  private validateConfiguration(): void {
+    if (!Number.isFinite(this.criticalTemperatureC)) {
+      throw new Error("criticalTemperatureC must be a finite number");
+    }
+    if (!Number.isFinite(this.recoveryTemperatureC)) {
+      throw new Error("recoveryTemperatureC must be a finite number");
+    }
+    if (this.recoveryTemperatureC >= this.criticalTemperatureC) {
+      throw new Error(
+        "recoveryTemperatureC must be lower than criticalTemperatureC",
+      );
+    }
+    if (
+      !Number.isFinite(this.samplingIntervalMs) ||
+      this.samplingIntervalMs < 0
+    ) {
+      throw new Error(
+        "samplingIntervalMs must be a non-negative finite number",
+      );
+    }
+  }
+}

--- a/packages/eufy-stream-server/src/thermal-governor.ts
+++ b/packages/eufy-stream-server/src/thermal-governor.ts
@@ -87,7 +87,7 @@ export class ThermalGovernor {
    * Concurrent callers share one temperature read and observe the same state.
    */
   public async checkCompatibilityEncoderAdmission(): Promise<boolean> {
-    if (this.isSamplingDue()) {
+    if (this.sampleInFlight || this.isSamplingDue()) {
       await this.sample();
     }
 

--- a/packages/eufy-stream-server/tests/compatibility-encoder-pool.test.ts
+++ b/packages/eufy-stream-server/tests/compatibility-encoder-pool.test.ts
@@ -92,6 +92,36 @@ describe("CompatibilityEncoderPool", () => {
     ]);
   });
 
+  it("reserves the requesting slot before a preemption callback can reenter acquire", () => {
+    const pool = new CompatibilityEncoderPool({ capacity: 1 });
+    let reentrantError: unknown;
+    pool.acquire({
+      serialNumber: "camera-a",
+      consumerKind: "prebuffer",
+      onPreempt: () => {
+        try {
+          pool.acquire({ serialNumber: "camera-a", consumerKind: "interactive" });
+        } catch (error) {
+          reentrantError = error;
+        }
+      },
+    });
+
+    const requester = pool.acquire({
+      serialNumber: "camera-b",
+      consumerKind: "interactive",
+    });
+
+    expect(requester.serialNumber).toBe("camera-b");
+    expect(reentrantError).toBeInstanceOf(CompatibilityEncoderCapacityError);
+    expect(pool.diagnostics).toEqual([
+      expect.objectContaining({
+        serialNumber: "camera-b",
+        consumers: { interactive: 1, prebuffer: 0 },
+      }),
+    ]);
+  });
+
   it("never preempts an interactive holder", () => {
     const pool = new CompatibilityEncoderPool({ capacity: 2 });
     pool.acquire({ serialNumber: "camera-1", consumerKind: "interactive" });

--- a/packages/eufy-stream-server/tests/compatibility-encoder-pool.test.ts
+++ b/packages/eufy-stream-server/tests/compatibility-encoder-pool.test.ts
@@ -1,0 +1,151 @@
+import {
+  CompatibilityEncoderCapacityError,
+  CompatibilityEncoderPool,
+} from "../src/compatibility-encoder-pool";
+
+describe("CompatibilityEncoderPool", () => {
+  it("uses a bounded default capacity derived from the CPU count", () => {
+    expect(new CompatibilityEncoderPool({ cpuCount: 1 }).capacity).toBe(1);
+    expect(new CompatibilityEncoderPool({ cpuCount: 7 }).capacity).toBe(3);
+    expect(new CompatibilityEncoderPool({ cpuCount: 24 }).capacity).toBe(4);
+  });
+
+  it("shares one slot when a camera acquires more than one consumer", () => {
+    const pool = new CompatibilityEncoderPool({ capacity: 1 });
+    const prebuffer = pool.acquire({
+      serialNumber: "camera-1",
+      name: "Front door",
+      consumerKind: "prebuffer",
+    });
+    const interactive = pool.acquire({
+      serialNumber: "camera-1",
+      consumerKind: "interactive",
+    });
+
+    expect(pool.diagnostics).toEqual([
+      expect.objectContaining({
+        serialNumber: "camera-1",
+        name: "Front door",
+        consumers: { interactive: 1, prebuffer: 1 },
+        preemptible: false,
+      }),
+    ]);
+
+    prebuffer.release();
+    interactive.release();
+  });
+
+  it("denies capacity with actionable holder diagnostics", () => {
+    const pool = new CompatibilityEncoderPool({ capacity: 1 });
+    pool.acquire({
+      serialNumber: "camera-1",
+      name: "Driveway",
+      consumerKind: "interactive",
+    });
+
+    let error: unknown;
+    try {
+      pool.acquire({ serialNumber: "camera-2", consumerKind: "prebuffer" });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(CompatibilityEncoderCapacityError);
+    expect(error).toMatchObject({
+      code: "COMPATIBILITY_ENCODER_CAPACITY",
+      requestedSerialNumber: "camera-2",
+      holders: [expect.objectContaining({ serialNumber: "camera-1", name: "Driveway" })],
+    });
+  });
+
+  it("makes a prebuffer holder non-preemptible while an interactive consumer is attached", () => {
+    const pool = new CompatibilityEncoderPool({ capacity: 1 });
+    pool.acquire({ serialNumber: "camera-1", consumerKind: "prebuffer" });
+    pool.acquire({ serialNumber: "camera-1", consumerKind: "interactive" });
+
+    expect(() =>
+      pool.acquire({ serialNumber: "camera-2", consumerKind: "interactive" }),
+    ).toThrow(CompatibilityEncoderCapacityError);
+    expect(pool.diagnostics[0]).toMatchObject({ serialNumber: "camera-1", preemptible: false });
+  });
+
+  it("preempts the oldest all-prebuffer holder for an interactive request", () => {
+    let clock = 100;
+    const pool = new CompatibilityEncoderPool({ capacity: 2, now: () => clock });
+    const evictOldest = jest.fn(() => {
+      throw new Error("eviction cleanup must not block capacity release");
+    });
+    pool.acquire({
+      serialNumber: "camera-1",
+      consumerKind: "prebuffer",
+      onPreempt: evictOldest,
+    });
+    clock++;
+    pool.acquire({ serialNumber: "camera-2", consumerKind: "prebuffer" });
+
+    pool.acquire({ serialNumber: "camera-3", consumerKind: "interactive" });
+
+    expect(evictOldest).toHaveBeenCalledTimes(1);
+    expect(pool.diagnostics.map((holder) => holder.serialNumber)).toEqual([
+      "camera-2",
+      "camera-3",
+    ]);
+  });
+
+  it("never preempts an interactive holder", () => {
+    const pool = new CompatibilityEncoderPool({ capacity: 2 });
+    pool.acquire({ serialNumber: "camera-1", consumerKind: "interactive" });
+    pool.acquire({ serialNumber: "camera-2", consumerKind: "interactive" });
+
+    expect(() =>
+      pool.acquire({ serialNumber: "camera-3", consumerKind: "interactive" }),
+    ).toThrow(CompatibilityEncoderCapacityError);
+  });
+
+  it("does not let a displaced prebuffer cascade by evicting another holder during cooldown", () => {
+    let clock = 100;
+    const pool = new CompatibilityEncoderPool({
+      capacity: 1,
+      now: () => clock,
+      preemptionCooldownMs: 1000,
+    });
+    pool.acquire({ serialNumber: "camera-1", consumerKind: "prebuffer" });
+    const interactive = pool.acquire({
+      serialNumber: "camera-2",
+      consumerKind: "interactive",
+    });
+
+    expect(() =>
+      pool.acquire({ serialNumber: "camera-1", consumerKind: "prebuffer" }),
+    ).toThrow(CompatibilityEncoderCapacityError);
+    expect(pool.diagnostics).toEqual([
+      expect.objectContaining({ serialNumber: "camera-2", preemptible: false }),
+    ]);
+
+    clock += 1001;
+    interactive.release();
+    const reAdmitted = pool.acquire({
+      serialNumber: "camera-1",
+      consumerKind: "prebuffer",
+    });
+    expect(pool.diagnostics[0]).toMatchObject({ serialNumber: "camera-1", preemptible: true });
+    reAdmitted.release();
+  });
+
+  it("releases leases idempotently and updates consumer composition on detach", () => {
+    const pool = new CompatibilityEncoderPool({ capacity: 1 });
+    const prebuffer = pool.acquire({ serialNumber: "camera-1", consumerKind: "prebuffer" });
+    const interactive = pool.acquire({ serialNumber: "camera-1", consumerKind: "interactive" });
+
+    interactive.release();
+    interactive.release();
+    expect(pool.diagnostics[0]).toMatchObject({
+      consumers: { interactive: 0, prebuffer: 1 },
+      preemptible: true,
+    });
+
+    prebuffer.release();
+    prebuffer.release();
+    expect(pool.diagnostics).toEqual([]);
+  });
+});

--- a/packages/eufy-stream-server/tests/compatibility-encoder-pool.test.ts
+++ b/packages/eufy-stream-server/tests/compatibility-encoder-pool.test.ts
@@ -132,6 +132,31 @@ describe("CompatibilityEncoderPool", () => {
     reAdmitted.release();
   });
 
+  it("does not let a displaced camera evict another prebuffer holder during cooldown", () => {
+    const pool = new CompatibilityEncoderPool({
+      capacity: 1,
+      now: () => 100,
+      preemptionCooldownMs: 1000,
+    });
+    pool.acquire({ serialNumber: "camera-a", consumerKind: "prebuffer" });
+    const cameraBInteractive = pool.acquire({
+      serialNumber: "camera-b",
+      consumerKind: "interactive",
+    });
+
+    // Free the interactive slot, then let B occupy it with a prebuffer. A's
+    // retry is interactive, so this proves cooldown—not consumer kind—blocks
+    // a cascade eviction of B.
+    cameraBInteractive.release();
+    pool.acquire({ serialNumber: "camera-b", consumerKind: "prebuffer" });
+    expect(() =>
+      pool.acquire({ serialNumber: "camera-a", consumerKind: "interactive" }),
+    ).toThrow(CompatibilityEncoderCapacityError);
+    expect(pool.diagnostics).toEqual([
+      expect.objectContaining({ serialNumber: "camera-b", preemptible: true }),
+    ]);
+  });
+
   it("releases leases idempotently and updates consumer composition on detach", () => {
     const pool = new CompatibilityEncoderPool({ capacity: 1 });
     const prebuffer = pool.acquire({ serialNumber: "camera-1", consumerKind: "prebuffer" });

--- a/packages/eufy-stream-server/tests/fmp4-box-stream.test.ts
+++ b/packages/eufy-stream-server/tests/fmp4-box-stream.test.ts
@@ -130,6 +130,16 @@ describe("Fmp4BoxStream", () => {
     expect(fragments).toEqual([]);
   });
 
+  it("resets malformed input without throwing when no error listener is registered", () => {
+    const stream = new Fmp4BoxStream();
+    const invalid = Buffer.alloc(8);
+    invalid.writeUInt32BE(7, 0);
+    invalid.write("free", 4, 4, "ascii");
+
+    expect(() => stream.write(invalid)).not.toThrow();
+    expect(() => stream.write(box("ftyp"))).not.toThrow();
+  });
+
   it("rejects oversized 32-bit and extended-size box declarations before buffering payloads", () => {
     const stream = new Fmp4BoxStream();
     const errors: Error[] = [];
@@ -163,6 +173,21 @@ describe("Fmp4BoxStream", () => {
 
     stream.write(Buffer.concat([box("ftyp"), box("moov")]));
     expect(inits).toEqual([Buffer.concat([box("ftyp"), box("moov")])]);
+  });
+
+  it("assembles fragmented large boxes without repeated Buffer.concat calls", () => {
+    const stream = new Fmp4BoxStream();
+    const free = box("free", Buffer.alloc(512 * 1024, 0xab));
+    const concatSpy = jest.spyOn(Buffer, "concat");
+
+    try {
+      for (let offset = 0; offset < free.length; offset += 4096) {
+        stream.write(free.subarray(offset, offset + 4096));
+      }
+      expect(concatSpy).not.toHaveBeenCalled();
+    } finally {
+      concatSpy.mockRestore();
+    }
   });
 });
 

--- a/packages/eufy-stream-server/tests/fmp4-box-stream.test.ts
+++ b/packages/eufy-stream-server/tests/fmp4-box-stream.test.ts
@@ -1,0 +1,187 @@
+import {
+  Fmp4BoxStream,
+  findVideoTrackId,
+  moofFirstSampleIsSync,
+} from "../src";
+
+const box = (type: string, payload: Uint8Array = Buffer.alloc(0)): Buffer => {
+  const result = Buffer.alloc(8 + payload.length);
+  result.writeUInt32BE(result.length, 0);
+  result.write(type, 4, 4, "ascii");
+  result.set(payload, 8);
+  return result;
+};
+
+const fullBox = (
+  type: string,
+  flags: number,
+  payload: Uint8Array = Buffer.alloc(0),
+): Buffer => {
+  const header = Buffer.alloc(4);
+  header.writeUInt32BE(flags, 0);
+  return box(type, Buffer.concat([header, payload]));
+};
+
+const tkhd = (trackId: number, version = 0): Buffer => {
+  const payload = Buffer.alloc(version === 1 ? 24 : 16);
+  payload[0] = version;
+  payload.writeUInt32BE(trackId, version === 1 ? 20 : 12);
+  return box("tkhd", payload);
+};
+
+const hdlr = (handlerType: string): Buffer => {
+  const payload = Buffer.alloc(12);
+  payload.write(handlerType, 8, 4, "ascii");
+  return box("hdlr", payload);
+};
+
+const trak = (trackId: number, handlerType: string, version = 0): Buffer =>
+  box("trak", Buffer.concat([tkhd(trackId, version), box("mdia", hdlr(handlerType))]));
+
+const tfhd = (trackId: number, defaultSampleFlags?: number): Buffer => {
+  const hasDefaultFlags = defaultSampleFlags !== undefined;
+  const payload = Buffer.alloc(hasDefaultFlags ? 8 : 4);
+  payload.writeUInt32BE(trackId, 0);
+  if (hasDefaultFlags) payload.writeUInt32BE(defaultSampleFlags, 4);
+  return fullBox("tfhd", hasDefaultFlags ? 0x20 : 0, payload);
+};
+
+const trun = (options: {
+  sampleCount?: number;
+  firstSampleFlags?: number;
+  sampleFlags?: number;
+} = {}): Buffer => {
+  const sampleCount = options.sampleCount ?? 1;
+  const hasFirstSampleFlags = options.firstSampleFlags !== undefined;
+  const hasSampleFlags = options.sampleFlags !== undefined;
+  const payload = Buffer.alloc(
+    4 + (hasFirstSampleFlags ? 4 : 0) + (hasSampleFlags ? 4 * sampleCount : 0),
+  );
+  payload.writeUInt32BE(sampleCount, 0);
+  let offset = 4;
+  if (hasFirstSampleFlags) {
+    payload.writeUInt32BE(options.firstSampleFlags!, offset);
+    offset += 4;
+  }
+  if (hasSampleFlags) payload.writeUInt32BE(options.sampleFlags!, offset);
+  return fullBox(
+    "trun",
+    (hasFirstSampleFlags ? 0x4 : 0) | (hasSampleFlags ? 0x400 : 0),
+    payload,
+  );
+};
+
+const traf = (trackId: number, run: Buffer, defaultSampleFlags?: number): Buffer =>
+  box("traf", Buffer.concat([tfhd(trackId, defaultSampleFlags), run]));
+
+describe("Fmp4BoxStream", () => {
+  it("emits init and fragments when every byte arrives in its own chunk", () => {
+    const stream = new Fmp4BoxStream();
+    const init = Buffer.concat([box("ftyp", Buffer.from("isom")), box("moov")]);
+    const fragment = Buffer.concat([
+      box("styp"),
+      box("sidx"),
+      box("moof", Buffer.from([1, 2])),
+      box("mdat", Buffer.from([3, 4, 5])),
+    ]);
+    const inits: Buffer[] = [];
+    const fragments: Buffer[] = [];
+    stream.on("init", (data: Buffer) => inits.push(data));
+    stream.on("fragment", (data: Buffer) => fragments.push(data));
+
+    for (const byte of Buffer.concat([init, fragment])) stream.write(Buffer.from([byte]));
+
+    expect(inits).toEqual([init]);
+    expect(fragments).toEqual([fragment]);
+  });
+
+  it("drops unknown boxes without preventing later init or fragment output", () => {
+    const stream = new Fmp4BoxStream();
+    const init = Buffer.concat([box("ftyp"), box("moov")]);
+    const fragment = Buffer.concat([box("styp"), box("moof"), box("mdat")]);
+    const inits: Buffer[] = [];
+    const fragments: Buffer[] = [];
+    stream.on("init", (data: Buffer) => inits.push(data));
+    stream.on("fragment", (data: Buffer) => fragments.push(data));
+
+    stream.write(Buffer.concat([box("free"), init, box("free"), fragment, box("free")]));
+
+    expect(inits).toEqual([init]);
+    expect(fragments).toEqual([fragment]);
+  });
+
+  it("emits an error and clears partial state for an invalid box size", () => {
+    const stream = new Fmp4BoxStream();
+    const errors: Error[] = [];
+    const fragments: Buffer[] = [];
+    stream.on("error", (error: Error) => errors.push(error));
+    stream.on("fragment", (data: Buffer) => fragments.push(data));
+
+    const partial = Buffer.concat([box("styp"), box("moof")]);
+    stream.write(partial);
+    const invalid = Buffer.alloc(8);
+    invalid.writeUInt32BE(7, 0);
+    invalid.write("free", 4, 4, "ascii");
+    stream.write(invalid);
+    stream.write(box("mdat"));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toMatch(/invalid.*size/i);
+    expect(fragments).toEqual([]);
+  });
+
+  it("reset discards buffered bytes and incomplete boxes", () => {
+    const stream = new Fmp4BoxStream();
+    const inits: Buffer[] = [];
+    stream.on("init", (data: Buffer) => inits.push(data));
+
+    const ftyp = box("ftyp");
+    stream.write(ftyp.subarray(0, 5));
+    stream.reset();
+    stream.write(box("moov"));
+    expect(inits).toEqual([]);
+
+    stream.write(Buffer.concat([box("ftyp"), box("moov")]));
+    expect(inits).toEqual([Buffer.concat([box("ftyp"), box("moov")])]);
+  });
+});
+
+describe("findVideoTrackId", () => {
+  it("finds a video track ID from version 0 and version 1 tkhd boxes", () => {
+    const version0 = Buffer.concat([box("ftyp"), box("moov", Buffer.concat([trak(3, "soun"), trak(42, "vide")]))]);
+    const version1 = Buffer.concat([box("ftyp"), box("moov", trak(99, "vide", 1))]);
+
+    expect(findVideoTrackId(version0)).toBe(42);
+    expect(findVideoTrackId(version1)).toBe(99);
+  });
+
+  it("returns undefined when an init segment has no video track", () => {
+    const init = Buffer.concat([box("ftyp"), box("moov", trak(3, "soun"))]);
+    expect(findVideoTrackId(init)).toBeUndefined();
+  });
+});
+
+describe("moofFirstSampleIsSync", () => {
+  it("uses the matching video traf rather than an audio traf that appears first", () => {
+    const audio = traf(1, trun({ firstSampleFlags: 0 }));
+    const video = traf(2, trun({ firstSampleFlags: 0x00010000 }));
+    const moof = box("moof", Buffer.concat([audio, video]));
+    expect(moofFirstSampleIsSync(moof, 2)).toBe(false);
+  });
+
+  it("recognizes sync samples from trun flags and tfhd defaults", () => {
+    const fromPerSampleFlags = box("moof", traf(2, trun({ sampleFlags: 0 })));
+    const fromDefaultFlags = box("moof", traf(2, trun(), 0));
+
+    expect(moofFirstSampleIsSync(fromPerSampleFlags, 2)).toBe(true);
+    expect(moofFirstSampleIsSync(fromDefaultFlags, 2)).toBe(true);
+  });
+
+  it("returns false when a matching sample cannot be proven sync", () => {
+    const noVideo = box("moof", traf(1, trun({ firstSampleFlags: 0 })));
+    const noFlags = box("moof", traf(2, trun()));
+
+    expect(moofFirstSampleIsSync(noVideo, 2)).toBe(false);
+    expect(moofFirstSampleIsSync(noFlags, 2)).toBe(false);
+  });
+});

--- a/packages/eufy-stream-server/tests/fmp4-box-stream.test.ts
+++ b/packages/eufy-stream-server/tests/fmp4-box-stream.test.ts
@@ -130,6 +130,26 @@ describe("Fmp4BoxStream", () => {
     expect(fragments).toEqual([]);
   });
 
+  it("rejects oversized 32-bit and extended-size box declarations before buffering payloads", () => {
+    const stream = new Fmp4BoxStream();
+    const errors: Error[] = [];
+    stream.on("error", (error: Error) => errors.push(error));
+
+    const oversized = Buffer.alloc(8);
+    oversized.writeUInt32BE(0xffffffff, 0);
+    oversized.write("free", 4, 4, "ascii");
+    stream.write(oversized);
+
+    const extended = Buffer.alloc(16);
+    extended.writeUInt32BE(1, 0);
+    extended.write("free", 4, 4, "ascii");
+    extended.writeBigUInt64BE(0x100000000n, 8);
+    stream.write(extended);
+
+    expect(errors).toHaveLength(2);
+    expect(errors.every((error) => /invalid.*size/i.test(error.message))).toBe(true);
+  });
+
   it("reset discards buffered bytes and incomplete boxes", () => {
     const stream = new Fmp4BoxStream();
     const inits: Buffer[] = [];
@@ -183,5 +203,15 @@ describe("moofFirstSampleIsSync", () => {
 
     expect(moofFirstSampleIsSync(noVideo, 2)).toBe(false);
     expect(moofFirstSampleIsSync(noFlags, 2)).toBe(false);
+  });
+
+  it("returns false when a multi-sample trun omits later declared sample records", () => {
+    const payload = Buffer.alloc(8);
+    payload.writeUInt32BE(2, 0);
+    payload.writeUInt32BE(0, 4);
+    const truncatedFlags = fullBox("trun", 0x400, payload);
+    const moof = box("moof", traf(2, truncatedFlags));
+
+    expect(moofFirstSampleIsSync(moof, 2)).toBe(false);
   });
 });

--- a/packages/eufy-stream-server/tests/h264-compatibility-relay.integration.test.ts
+++ b/packages/eufy-stream-server/tests/h264-compatibility-relay.integration.test.ts
@@ -1,0 +1,239 @@
+import { execFileSync, spawn } from "node:child_process";
+import { once } from "node:events";
+import { writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import * as net from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { H264CompatibilityRelay } from "../src/h264-compatibility-relay";
+
+const TEST_TIMEOUT_MS = 30_000;
+const POLL_INTERVAL_MS = 100;
+
+function hasRequiredFfmpeg(): boolean {
+  try {
+    const encoders = execFileSync("ffmpeg", ["-hide_banner", "-encoders"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    execFileSync("ffprobe", ["-version"], { stdio: "ignore" });
+    return encoders.includes("libx264") && encoders.includes("libx265");
+  } catch {
+    return false;
+  }
+}
+
+const canRun = hasRequiredFfmpeg();
+
+async function runFfmpeg(args: string[]): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("ffmpeg", args, { stdio: ["ignore", "pipe", "pipe"] });
+    const output: Buffer[] = [];
+    const errors: Buffer[] = [];
+    child.stdout.on("data", (chunk: Buffer) => output.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => errors.push(chunk));
+    child.once("error", reject);
+    child.once("close", (code) => {
+      if (code === 0) {
+        resolve(Buffer.concat(output));
+      } else {
+        reject(
+          new Error(
+            `ffmpeg exited ${code}: ${Buffer.concat(errors).toString("utf8")}`,
+          ),
+        );
+      }
+    });
+  });
+}
+
+async function createHevcFmp4Fixture(): Promise<Buffer> {
+  return runFfmpeg([
+    "-hide_banner",
+    "-loglevel",
+    "error",
+    "-f",
+    "lavfi",
+    "-i",
+    "testsrc2=size=160x90:rate=5",
+    "-t",
+    "2",
+    "-an",
+    "-threads",
+    "1",
+    "-c:v",
+    "libx265",
+    "-preset",
+    "ultrafast",
+    "-x265-params",
+    "keyint=5:min-keyint=5:scenecut=0:pools=1:frame-threads=1:log-level=error",
+    "-movflags",
+    "frag_keyframe+empty_moov+default_base_moof",
+    "-f",
+    "mp4",
+    "pipe:1",
+  ]);
+}
+
+async function listen(server: net.Server): Promise<number> {
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  return (server.address() as net.AddressInfo).port;
+}
+
+async function connect(port: number): Promise<net.Socket> {
+  const socket = net.createConnection({ port, host: "127.0.0.1" });
+  await once(socket, "connect");
+  return socket;
+}
+
+async function closeServer(server: net.Server): Promise<void> {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+async function waitFor<T>(
+  description: string,
+  condition: () => T | undefined,
+): Promise<T> {
+  const deadline = Date.now() + TEST_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const value = condition();
+    if (value !== undefined) return value;
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+  throw new Error(`Timed out waiting for ${description}`);
+}
+
+function hasFmp4InitAndFragment(data: Buffer): boolean {
+  return (
+    data.includes(Buffer.from("moov")) &&
+    data.includes(Buffer.from("moof")) &&
+    data.includes(Buffer.from("mdat"))
+  );
+}
+
+function probeH264Fmp4(file: string): boolean {
+  try {
+    const result = execFileSync(
+      "ffprobe",
+      [
+        "-v",
+        "error",
+        "-show_entries",
+        "format=format_name:stream=codec_name",
+        "-of",
+        "default=noprint_wrappers=1",
+        file,
+      ],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    );
+    return (
+      result.includes("format_name=mov,mp4,m4a,3gp,3g2,mj2") &&
+      result.includes("codec_name=h264")
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function waitForDecodableH264Fmp4(
+  file: string,
+  received: Buffer[],
+): Promise<Buffer> {
+  return waitFor("decodable H.264 fMP4 output", () => {
+    const output = Buffer.concat(received);
+    if (!hasFmp4InitAndFragment(output)) return undefined;
+    writeFileSync(file, output);
+    return probeH264Fmp4(file) ? output : undefined;
+  });
+}
+
+async function assertFfmpegDecodes(file: string): Promise<void> {
+  await runFfmpeg([
+    "-hide_banner",
+    "-loglevel",
+    "error",
+    "-i",
+    file,
+    "-frames:v",
+    "1",
+    "-f",
+    "null",
+    "-",
+  ]);
+}
+
+// This test is deliberately self-skipping for developer machines that have
+// no FFmpeg or were built without either GPL encoder. CI installs and checks
+// these requirements before invoking this test.
+(canRun ? describe : describe.skip)(
+  "H264CompatibilityRelay FFmpeg integration",
+  () => {
+    jest.setTimeout(TEST_TIMEOUT_MS + 5_000);
+
+    it("transcodes HEVC fMP4 to decodable H.264 fMP4 and replays a keyframe to a late consumer", async () => {
+      const fixture = await createHevcFmp4Fixture();
+      expect(hasFmp4InitAndFragment(fixture)).toBe(true);
+
+      let sourceSocket: net.Socket | undefined;
+      let resolveSourceConnection: ((socket: net.Socket) => void) | undefined;
+      const sourceConnection = new Promise<net.Socket>((resolve) => {
+        resolveSourceConnection = resolve;
+      });
+      const sourceServer = net.createServer((socket) => {
+        sourceSocket = socket;
+        socket.on("error", () => undefined);
+        resolveSourceConnection?.(socket);
+      });
+      const sourcePort = await listen(sourceServer);
+      const outputDirectory = await mkdtemp(join(tmpdir(), "eufy-h264-relay-"));
+      const firstOutputFile = join(outputDirectory, "first.mp4");
+      const lateOutputFile = join(outputDirectory, "late.mp4");
+      const relay = new H264CompatibilityRelay({
+        serialNumber: "ffmpeg-integration-camera",
+        getMuxedPort: () => sourcePort,
+        ffmpegPath: "ffmpeg",
+        lingerMs: TEST_TIMEOUT_MS,
+      });
+      const sockets: net.Socket[] = [];
+
+      try {
+        await relay.start();
+        const upstream = await sourceConnection;
+        const relayPort = relay.getPort();
+        expect(relayPort).toBeDefined();
+
+        const first = await connect(relayPort!);
+        sockets.push(first);
+        const firstReceived: Buffer[] = [];
+        first.on("data", (chunk: Buffer) => firstReceived.push(chunk));
+
+        upstream.write(fixture);
+        const firstOutput = await waitForDecodableH264Fmp4(
+          firstOutputFile,
+          firstReceived,
+        );
+        await assertFfmpegDecodes(firstOutputFile);
+        expect(firstOutput.length).toBeGreaterThan(0);
+
+        const late = await connect(relayPort!);
+        sockets.push(late);
+        const lateReceived: Buffer[] = [];
+        late.on("data", (chunk: Buffer) => lateReceived.push(chunk));
+
+        const lateOutput = await waitForDecodableH264Fmp4(
+          lateOutputFile,
+          lateReceived,
+        );
+        await assertFfmpegDecodes(lateOutputFile);
+        expect(lateOutput.length).toBeGreaterThan(0);
+      } finally {
+        for (const socket of sockets) socket.destroy();
+        sourceSocket?.destroy();
+        await relay.stop();
+        await closeServer(sourceServer);
+        await rm(outputDirectory, { recursive: true, force: true });
+      }
+    });
+  },
+);

--- a/packages/eufy-stream-server/tests/h264-compatibility-relay.test.ts
+++ b/packages/eufy-stream-server/tests/h264-compatibility-relay.test.ts
@@ -97,7 +97,28 @@ describe("H264CompatibilityRelay", () => {
     expect(second).toBe(first);
     await Promise.all([first.start(), second.start()]);
     await first.stop();
-    expect(getSharedH264CompatibilityRelay(options)).not.toBe(first);
+    expect(getSharedH264CompatibilityRelay(options)).toBe(first);
+    await new Promise<void>((resolve) => source.server.close(() => resolve()));
+  });
+
+  it("keeps the factory identity through stop plus a queued restart", async () => {
+    const source = await sourceServer();
+    const firstChild = new FakeChild();
+    const secondChild = new FakeChild();
+    const options = {
+      serialNumber: "restart-shared-camera", getMuxedPort: () => source.port, ffmpegPath: "/fake/ffmpeg",
+      createChildProcess: jest.fn().mockReturnValueOnce(firstChild).mockReturnValueOnce(secondChild),
+    };
+    const relay = getSharedH264CompatibilityRelay(options);
+    await relay.start();
+    const stopped = new Promise<void>((resolve) => relay.once("stopped", () => resolve()));
+    const stopping = relay.stop();
+    const restarting = relay.start();
+    await stopped;
+    expect(getSharedH264CompatibilityRelay(options)).toBe(relay);
+    await Promise.all([stopping, restarting]);
+    expect(options.createChildProcess).toHaveBeenCalledTimes(2);
+    await relay.stop();
     await new Promise<void>((resolve) => source.server.close(() => resolve()));
   });
 
@@ -126,9 +147,8 @@ describe("H264CompatibilityRelay", () => {
     await new Promise<void>((resolve) => first.once("connect", resolve));
 
     const expected = Buffer.concat([initSegment(), fragment(1, true)]);
-    const firstRead = readLength(first, expected.length);
     child.stdout.write(Buffer.concat([initSegment(), fragment(2, true), fragment(1, true)]));
-    expect((await firstRead).subarray(0, expected.length)).toEqual(expected);
+    await new Promise((resolve) => setImmediate(resolve));
 
     const late = net.createConnection({ port, host: "127.0.0.1" });
     await new Promise<void>((resolve) => late.once("connect", resolve));

--- a/packages/eufy-stream-server/tests/h264-compatibility-relay.test.ts
+++ b/packages/eufy-stream-server/tests/h264-compatibility-relay.test.ts
@@ -46,7 +46,10 @@ class FakeChild extends EventEmitter {
   public readonly stdin = new PassThrough();
   public readonly stdout = new PassThrough();
   public readonly stderr = new PassThrough();
-  public readonly kill = jest.fn();
+  public readonly kill = jest.fn((signal?: NodeJS.Signals | number) => {
+    setImmediate(() => this.emit("exit", null, signal));
+    return true;
+  });
 }
 
 class PendingSource extends EventEmitter {
@@ -294,6 +297,28 @@ describe("H264CompatibilityRelay", () => {
     await Promise.all([relay.stop(), relay.stop()]);
     expect(child.kill).toHaveBeenCalledTimes(1);
     expect(relay.getPort()).toBeUndefined();
+    await new Promise<void>((resolve) => source.server.close(() => resolve()));
+  });
+
+  it("waits for FFmpeg exit and escalates from TERM to KILL when it does not reap", async () => {
+    const source = await sourceServer();
+    const child = new FakeChild();
+    child.kill.mockImplementation((signal?: NodeJS.Signals | number) => {
+      if (signal === "SIGKILL") setImmediate(() => child.emit("exit", null, "SIGKILL"));
+      return true;
+    });
+    const relay = new H264CompatibilityRelay({
+      serialNumber: "camera-1", getMuxedPort: () => source.port, ffmpegPath: "/fake/ffmpeg",
+      createChildProcess: () => child, childExitTimeoutMs: 5,
+    });
+    await relay.start();
+    let stopped = false;
+    const stopping = relay.stop().then(() => { stopped = true; });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(stopped).toBe(false);
+    await stopping;
+    expect(child.kill).toHaveBeenNthCalledWith(1, "SIGTERM");
+    expect(child.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
     await new Promise<void>((resolve) => source.server.close(() => resolve()));
   });
 

--- a/packages/eufy-stream-server/tests/h264-compatibility-relay.test.ts
+++ b/packages/eufy-stream-server/tests/h264-compatibility-relay.test.ts
@@ -1,8 +1,10 @@
 import {
+  disposeSharedH264CompatibilityRelay,
   getSharedH264CompatibilityRelay,
   H264CompatibilityRelay,
 } from "../src/h264-compatibility-relay";
 import {
+  disposeSharedH264CompatibilityRelay as exportedDisposeSharedRelay,
   getSharedH264CompatibilityRelay as exportedSharedRelay,
   H264CompatibilityRelay as ExportedRelay,
 } from "../src";
@@ -57,6 +59,17 @@ class PendingSource extends EventEmitter {
   }
 }
 
+class ControlledSource extends PendingSource {
+  public destroy(): this {
+    this.destroyed = true;
+    return this;
+  }
+
+  public finishClose(): void {
+    this.emit("close");
+  }
+}
+
 async function sourceServer(): Promise<{ server: net.Server; port: number }> {
   const server = net.createServer();
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
@@ -83,6 +96,7 @@ describe("H264CompatibilityRelay", () => {
   it("is exported by the package entry point", () => {
     expect(ExportedRelay).toBe(H264CompatibilityRelay);
     expect(exportedSharedRelay).toBe(getSharedH264CompatibilityRelay);
+    expect(exportedDisposeSharedRelay).toBe(disposeSharedH264CompatibilityRelay);
   });
 
   it("returns a process-shared relay for the same camera without a manually injected pool", async () => {
@@ -119,6 +133,24 @@ describe("H264CompatibilityRelay", () => {
     await Promise.all([stopping, restarting]);
     expect(options.createChildProcess).toHaveBeenCalledTimes(2);
     await relay.stop();
+    await new Promise<void>((resolve) => source.server.close(() => resolve()));
+  });
+
+  it("permanently disposes an old shared relay before a replacement can be created", async () => {
+    const source = await sourceServer();
+    const options = {
+      serialNumber: "disposed-shared-camera", getMuxedPort: () => source.port, ffmpegPath: "/fake/ffmpeg",
+      createChildProcess: () => new FakeChild(),
+    };
+    const oldRelay = getSharedH264CompatibilityRelay(options);
+    await oldRelay.start();
+    await disposeSharedH264CompatibilityRelay(options.serialNumber);
+    const replacement = getSharedH264CompatibilityRelay(options);
+    expect(replacement).not.toBe(oldRelay);
+    await expect(oldRelay.start()).rejects.toThrow("disposed");
+    await replacement.start();
+    await replacement.stop();
+    await disposeSharedH264CompatibilityRelay(options.serialNumber);
     await new Promise<void>((resolve) => source.server.close(() => resolve()));
   });
 
@@ -260,6 +292,45 @@ describe("H264CompatibilityRelay", () => {
     await expect(starting).rejects.toThrow("cancelled");
     expect(child.kill).toHaveBeenCalledTimes(1);
     expect(relay.getPort()).toBeUndefined();
+  });
+
+  it("closes the listener before awaiting source teardown so a racing client cannot keep stop open", async () => {
+    const child = new FakeChild();
+    const source = new ControlledSource();
+    const relay = new H264CompatibilityRelay({
+      serialNumber: "camera-1", getMuxedPort: () => 12345, ffmpegPath: "/fake/ffmpeg",
+      createChildProcess: () => child,
+      net: {
+        createServer: net.createServer,
+        createConnection: () => {
+          setImmediate(() => source.emit("connect"));
+          return source as unknown as net.Socket;
+        },
+      },
+    });
+    await relay.start();
+    const port = relay.getPort()!;
+    const stopping = relay.stop();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(relay.getPort()).toBeUndefined();
+    const racingClient = net.createConnection({ port, host: "127.0.0.1" });
+    await new Promise<void>((resolve) => racingClient.once("error", () => resolve()));
+    source.finishClose();
+    await stopping;
+  });
+
+  it("contains current-generation stdio EPIPE errors and tears down safely", async () => {
+    const source = await sourceServer();
+    const child = new FakeChild();
+    const relay = new H264CompatibilityRelay({
+      serialNumber: "camera-1", getMuxedPort: () => source.port, ffmpegPath: "/fake/ffmpeg",
+      createChildProcess: () => child,
+    });
+    await relay.start();
+    const stopped = new Promise<void>((resolve) => relay.once("stopped", () => resolve()));
+    expect(() => child.stdin.emit("error", Object.assign(new Error("broken pipe"), { code: "EPIPE" }))).not.toThrow();
+    await stopped;
+    await new Promise<void>((resolve) => source.server.close(() => resolve()));
   });
 
   it("ignores delayed stdout and process failures from a prior generation", async () => {

--- a/packages/eufy-stream-server/tests/h264-compatibility-relay.test.ts
+++ b/packages/eufy-stream-server/tests/h264-compatibility-relay.test.ts
@@ -1,0 +1,228 @@
+import { H264CompatibilityRelay } from "../src/h264-compatibility-relay";
+import { H264CompatibilityRelay as ExportedRelay } from "../src";
+import { CompatibilityEncoderPool } from "../src/compatibility-encoder-pool";
+import { EventEmitter } from "node:events";
+import * as net from "node:net";
+import { PassThrough } from "node:stream";
+
+function box(type: string, data: Buffer = Buffer.alloc(0)): Buffer {
+  const result = Buffer.alloc(8 + data.length);
+  result.writeUInt32BE(result.length, 0);
+  result.write(type, 4, 4, "ascii");
+  data.copy(result, 8);
+  return result;
+}
+
+function initSegment(): Buffer {
+  const tkhd = Buffer.alloc(20);
+  tkhd.writeUInt32BE(1, 12);
+  const hdlr = Buffer.alloc(12);
+  hdlr.write("vide", 8, 4, "ascii");
+  return Buffer.concat([
+    box("ftyp"),
+    box("moov", box("trak", Buffer.concat([box("tkhd", tkhd), box("mdia", box("hdlr", hdlr))]))),
+  ]);
+}
+
+function fragment(trackId: number, sync: boolean): Buffer {
+  const tfhd = Buffer.alloc(8);
+  tfhd.writeUInt32BE(trackId, 4);
+  const trun = Buffer.alloc(12);
+  trun.writeUInt32BE(0x000004, 0);
+  trun.writeUInt32BE(1, 4);
+  trun.writeUInt32BE(sync ? 0 : 0x00010000, 8);
+  return Buffer.concat([box("moof", box("traf", Buffer.concat([box("tfhd", tfhd), box("trun", trun)]))), box("mdat", Buffer.from([trackId]))]);
+}
+
+class FakeChild extends EventEmitter {
+  public readonly stdin = new PassThrough();
+  public readonly stdout = new PassThrough();
+  public readonly stderr = new PassThrough();
+  public readonly kill = jest.fn();
+}
+
+async function sourceServer(): Promise<{ server: net.Server; port: number }> {
+  const server = net.createServer();
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return { server, port: (server.address() as net.AddressInfo).port };
+}
+
+async function readLength(socket: net.Socket, length: number): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  return new Promise((resolve) => {
+    const onData = (chunk: Buffer) => {
+      chunks.push(chunk);
+      total += chunk.length;
+      if (total >= length) {
+        socket.off("data", onData);
+        resolve(Buffer.concat(chunks));
+      }
+    };
+    socket.on("data", onData);
+  });
+}
+
+describe("H264CompatibilityRelay", () => {
+  it("is exported by the package entry point", () => {
+    expect(ExportedRelay).toBe(H264CompatibilityRelay);
+  });
+
+  it("fails with an actionable error when no ffmpeg path is configured", async () => {
+    const relay = new H264CompatibilityRelay({
+      serialNumber: "camera-1",
+      getMuxedPort: () => 12345,
+    });
+
+    await expect(relay.start()).rejects.toThrow("ffmpeg path");
+  });
+
+  it("shares one encoder and replays init plus the latest video sync fragment to late clients", async () => {
+    const source = await sourceServer();
+    const child = new FakeChild();
+    const spawn = jest.fn(() => child);
+    const relay = new H264CompatibilityRelay({
+      serialNumber: "camera-1",
+      getMuxedPort: () => source.port,
+      ffmpegPath: "/fake/ffmpeg",
+      createChildProcess: spawn,
+    });
+    await relay.start();
+    const port = relay.getPort();
+    const first = net.createConnection({ port, host: "127.0.0.1" });
+    await new Promise<void>((resolve) => first.once("connect", resolve));
+
+    const expected = Buffer.concat([initSegment(), fragment(1, true)]);
+    const firstRead = readLength(first, expected.length);
+    child.stdout.write(Buffer.concat([initSegment(), fragment(2, true), fragment(1, true)]));
+    expect((await firstRead).subarray(0, expected.length)).toEqual(expected);
+
+    const late = net.createConnection({ port, host: "127.0.0.1" });
+    await new Promise<void>((resolve) => late.once("connect", resolve));
+    expect((await readLength(late, expected.length)).subarray(0, expected.length)).toEqual(expected);
+    expect(spawn).toHaveBeenCalledTimes(1);
+
+    first.destroy();
+    late.destroy();
+    await relay.stop();
+    await new Promise<void>((resolve) => source.server.close(() => resolve()));
+  });
+
+  it("keeps its encoder warm through linger and releases it only after expiry", async () => {
+    const source = await sourceServer();
+    const child = new FakeChild();
+    const pool = new CompatibilityEncoderPool({ capacity: 1 });
+    const relay = new H264CompatibilityRelay({
+      serialNumber: "camera-1", getMuxedPort: () => source.port, ffmpegPath: "/fake/ffmpeg",
+      createChildProcess: () => child, pool, lingerMs: 20,
+    });
+    await relay.start();
+    const socket = net.createConnection({ port: relay.getPort(), host: "127.0.0.1" });
+    await new Promise<void>((resolve) => socket.once("connect", resolve));
+    socket.destroy();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(pool.diagnostics).toHaveLength(1);
+    const reconnect = net.createConnection({ port: relay.getPort(), host: "127.0.0.1" });
+    await new Promise<void>((resolve) => reconnect.once("connect", resolve));
+    expect(child.kill).not.toHaveBeenCalled();
+    reconnect.destroy();
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    expect(pool.diagnostics).toHaveLength(0);
+    await new Promise<void>((resolve) => source.server.close(() => resolve()));
+  });
+
+  it("stops consumers with a pool-preemption reason", async () => {
+    const source = await sourceServer();
+    const child = new FakeChild();
+    const pool = new CompatibilityEncoderPool({ capacity: 1 });
+    const relay = new H264CompatibilityRelay({
+      serialNumber: "camera-1", getMuxedPort: () => source.port, ffmpegPath: "/fake/ffmpeg",
+      createChildProcess: () => child, pool,
+    });
+    await relay.start();
+    const events: unknown[] = [];
+    relay.on("preempted", (event) => events.push(event));
+    pool.acquire({ serialNumber: "camera-2", consumerKind: "interactive" });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(events).toEqual([{ serialNumber: "camera-1", reason: "encoder-pool-preempted" }]);
+    expect(child.kill).toHaveBeenCalled();
+    await new Promise<void>((resolve) => source.server.close(() => resolve()));
+  });
+
+  it("isolates a slow client after two queued fragments while healthy clients continue", () => {
+    const relay = new H264CompatibilityRelay({ serialNumber: "camera-1" });
+    const slow = Object.assign(new EventEmitter(), {
+      destroyed: false, write: jest.fn(() => false), destroy: jest.fn(),
+    }) as unknown as net.Socket;
+    const healthy = Object.assign(new EventEmitter(), {
+      destroyed: false, write: jest.fn(() => true), destroy: jest.fn(),
+    }) as unknown as net.Socket;
+    const consumer = (socket: net.Socket) => ({ socket, queue: [], queuedBytes: 0, blocked: false, closed: false, kind: "prebuffer" as const });
+    (relay as any).consumers.set(slow, consumer(slow));
+    (relay as any).consumers.set(healthy, consumer(healthy));
+    (relay as any).broadcast(Buffer.from("one"));
+    (relay as any).broadcast(Buffer.from("two"));
+    (relay as any).broadcast(Buffer.from("three"));
+    (relay as any).broadcast(Buffer.from("four"));
+    expect(slow.destroy).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining("overflow") }));
+    expect(healthy.write).toHaveBeenCalledTimes(4);
+  });
+
+  it("reports an unavailable muxed source before launching ffmpeg", async () => {
+    const spawn = jest.fn();
+    const relay = new H264CompatibilityRelay({
+      serialNumber: "camera-1", getMuxedPort: () => undefined, ffmpegPath: "/fake/ffmpeg", createChildProcess: spawn,
+    });
+    await expect(relay.start()).rejects.toThrow("muxed source is unavailable");
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("serializes start calls and makes stop idempotent", async () => {
+    const source = await sourceServer();
+    const child = new FakeChild();
+    const spawn = jest.fn(() => child);
+    const relay = new H264CompatibilityRelay({
+      serialNumber: "camera-1", getMuxedPort: () => source.port, ffmpegPath: "/fake/ffmpeg", createChildProcess: spawn,
+    });
+    await Promise.all([relay.start(), relay.start()]);
+    expect(spawn).toHaveBeenCalledTimes(1);
+    await Promise.all([relay.stop(), relay.stop()]);
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    expect(relay.getPort()).toBeUndefined();
+    await new Promise<void>((resolve) => source.server.close(() => resolve()));
+  });
+
+  it("invalidates a generation's cache when its muxed source disconnects", async () => {
+    let upstream: net.Socket | undefined;
+    let sourceConnected!: () => void;
+    const upstreamReady = new Promise<void>((resolve) => { sourceConnected = resolve; });
+    const source = net.createServer((socket) => { upstream = socket; sourceConnected(); });
+    await new Promise<void>((resolve) => source.listen(0, "127.0.0.1", resolve));
+    const port = (source.address() as net.AddressInfo).port;
+    const firstChild = new FakeChild();
+    const secondChild = new FakeChild();
+    const spawn = jest.fn().mockReturnValueOnce(firstChild).mockReturnValueOnce(secondChild);
+    const relay = new H264CompatibilityRelay({
+      serialNumber: "camera-1", getMuxedPort: () => port, ffmpegPath: "/fake/ffmpeg", createChildProcess: spawn,
+    });
+    relay.on("error", () => undefined);
+    await relay.start();
+    await upstreamReady;
+    firstChild.stdout.write(Buffer.concat([initSegment(), fragment(1, true)]));
+    await new Promise((resolve) => setImmediate(resolve));
+    upstream!.destroy();
+    await new Promise<void>((resolve) => relay.once("stopped", () => resolve()));
+    expect((relay as any).init).toBeUndefined();
+    await relay.start();
+    const client = net.createConnection({ port: relay.getPort(), host: "127.0.0.1" });
+    await new Promise<void>((resolve) => client.once("connect", resolve));
+    const expected = Buffer.concat([initSegment(), fragment(1, true)]);
+    const read = readLength(client, expected.length);
+    secondChild.stdout.write(expected);
+    expect((await read).subarray(0, expected.length)).toEqual(expected);
+    client.destroy();
+    await relay.stop();
+    await new Promise<void>((resolve) => source.close(() => resolve()));
+  });
+});

--- a/packages/eufy-stream-server/tests/h264-compatibility-relay.test.ts
+++ b/packages/eufy-stream-server/tests/h264-compatibility-relay.test.ts
@@ -1,5 +1,11 @@
-import { H264CompatibilityRelay } from "../src/h264-compatibility-relay";
-import { H264CompatibilityRelay as ExportedRelay } from "../src";
+import {
+  getSharedH264CompatibilityRelay,
+  H264CompatibilityRelay,
+} from "../src/h264-compatibility-relay";
+import {
+  getSharedH264CompatibilityRelay as exportedSharedRelay,
+  H264CompatibilityRelay as ExportedRelay,
+} from "../src";
 import { CompatibilityEncoderPool } from "../src/compatibility-encoder-pool";
 import { EventEmitter } from "node:events";
 import * as net from "node:net";
@@ -41,6 +47,16 @@ class FakeChild extends EventEmitter {
   public readonly kill = jest.fn();
 }
 
+class PendingSource extends EventEmitter {
+  public destroyed = false;
+  public readonly pipe = jest.fn();
+  public destroy(): this {
+    this.destroyed = true;
+    this.emit("close");
+    return this;
+  }
+}
+
 async function sourceServer(): Promise<{ server: net.Server; port: number }> {
   const server = net.createServer();
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
@@ -66,6 +82,23 @@ async function readLength(socket: net.Socket, length: number): Promise<Buffer> {
 describe("H264CompatibilityRelay", () => {
   it("is exported by the package entry point", () => {
     expect(ExportedRelay).toBe(H264CompatibilityRelay);
+    expect(exportedSharedRelay).toBe(getSharedH264CompatibilityRelay);
+  });
+
+  it("returns a process-shared relay for the same camera without a manually injected pool", async () => {
+    const source = await sourceServer();
+    const child = new FakeChild();
+    const options = {
+      serialNumber: "shared-camera", getMuxedPort: () => source.port, ffmpegPath: "/fake/ffmpeg",
+      createChildProcess: () => child,
+    };
+    const first = getSharedH264CompatibilityRelay(options);
+    const second = getSharedH264CompatibilityRelay(options);
+    expect(second).toBe(first);
+    await Promise.all([first.start(), second.start()]);
+    await first.stop();
+    expect(getSharedH264CompatibilityRelay(options)).not.toBe(first);
+    await new Promise<void>((resolve) => source.server.close(() => resolve()));
   });
 
   it("fails with an actionable error when no ffmpeg path is configured", async () => {
@@ -190,6 +223,45 @@ describe("H264CompatibilityRelay", () => {
     await Promise.all([relay.stop(), relay.stop()]);
     expect(child.kill).toHaveBeenCalledTimes(1);
     expect(relay.getPort()).toBeUndefined();
+    await new Promise<void>((resolve) => source.server.close(() => resolve()));
+  });
+
+  it("cancels an in-flight source connection when stop races start", async () => {
+    const child = new FakeChild();
+    const pendingSource = new PendingSource();
+    const relay = new H264CompatibilityRelay({
+      serialNumber: "camera-1", getMuxedPort: () => 12345, ffmpegPath: "/fake/ffmpeg",
+      createChildProcess: () => child,
+      net: { createServer: net.createServer, createConnection: () => pendingSource as unknown as net.Socket },
+    });
+    const starting = relay.start();
+    await new Promise((resolve) => setImmediate(resolve));
+    await relay.stop();
+    await expect(starting).rejects.toThrow("cancelled");
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    expect(relay.getPort()).toBeUndefined();
+  });
+
+  it("ignores delayed stdout and process failures from a prior generation", async () => {
+    const source = await sourceServer();
+    const firstChild = new FakeChild();
+    const secondChild = new FakeChild();
+    const spawn = jest.fn().mockReturnValueOnce(firstChild).mockReturnValueOnce(secondChild);
+    const relay = new H264CompatibilityRelay({
+      serialNumber: "camera-1", getMuxedPort: () => source.port, ffmpegPath: "/fake/ffmpeg", createChildProcess: spawn,
+    });
+    await relay.start();
+    await relay.stop();
+    await relay.start();
+    const generation = relay.generationId;
+    firstChild.stdout.write(Buffer.concat([initSegment(), fragment(1, true)]));
+    firstChild.emit("error", new Error("late failure"));
+    firstChild.emit("exit", 1, null);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(relay.generationId).toBe(generation);
+    expect((relay as any).init).toBeUndefined();
+    expect(secondChild.kill).not.toHaveBeenCalled();
+    await relay.stop();
     await new Promise<void>((resolve) => source.server.close(() => resolve()));
   });
 

--- a/packages/eufy-stream-server/tests/h264-compatibility-relay.test.ts
+++ b/packages/eufy-stream-server/tests/h264-compatibility-relay.test.ts
@@ -163,6 +163,25 @@ describe("H264CompatibilityRelay", () => {
     await expect(relay.start()).rejects.toThrow("ffmpeg path");
   });
 
+  it("configures FFmpeg for live fragmented output before upstream EOF", async () => {
+    const source = await sourceServer();
+    const child = new FakeChild();
+    const spawn = jest.fn((..._args: unknown[]) => child);
+    const relay = new H264CompatibilityRelay({
+      serialNumber: "camera-1", getMuxedPort: () => source.port, ffmpegPath: "/fake/ffmpeg",
+      createChildProcess: spawn,
+    });
+    await relay.start();
+    const args = spawn.mock.calls[0][1];
+    expect(args).toEqual(expect.arrayContaining([
+      "-threads", "1", "-blocksize", "4096", "-probesize", "4096", "-analyzeduration", "0",
+      "-preset", "ultrafast", "-tune", "zerolatency", "-movflags",
+      "frag_every_frame+empty_moov+default_base_moof", "-flush_packets", "1",
+    ]));
+    await relay.stop();
+    await new Promise<void>((resolve) => source.server.close(() => resolve()));
+  });
+
   it("shares one encoder and replays init plus the latest video sync fragment to late clients", async () => {
     const source = await sourceServer();
     const child = new FakeChild();

--- a/packages/eufy-stream-server/tests/stream-server.test.ts
+++ b/packages/eufy-stream-server/tests/stream-server.test.ts
@@ -1694,6 +1694,24 @@ describe("StreamServer", () => {
       expect((server as any).metadataWaiters.length).toBe(0);
     });
 
+    it("cancels pending metadata waits before server stop resolves", async () => {
+      await server.start();
+
+      const socket = net.createConnection({
+        port: server.getMuxedPort()!,
+        host: "127.0.0.1",
+      });
+      await new Promise((resolve) => socket.on("connect", resolve));
+      await wait(20);
+
+      expect((server as any).metadataWaiters.length).toBe(1);
+
+      await server.stop();
+
+      expect((server as any).metadataWaiters.length).toBe(0);
+      socket.destroy();
+    });
+
     it("JMuxer duplex data is written to socket", async () => {
       await server.start();
 

--- a/packages/eufy-stream-server/tests/stream-server.test.ts
+++ b/packages/eufy-stream-server/tests/stream-server.test.ts
@@ -1787,7 +1787,17 @@ describe("StreamServer", () => {
     });
 
     it("does not carry audio detection into a new metadata session", () => {
-      (server as any).audioMetadata = { audioCodec: "AAC" };
+      const audioListener = mockWsClient.addEventListener.mock.calls.find(
+        (call: any[]) => call[0] === "livestream audio data",
+      )[1];
+      audioListener({
+        serialNumber: "TEST_DEVICE_123",
+        buffer: {
+          data: Buffer.from([0xff, 0xf1, 0x50, 0x80, 0x00, 0x1f, 0xfc]),
+        },
+        metadata: { audioCodec: "AAC" },
+      });
+      expect(server.getAudioStatus()).toBe("aac");
 
       (server as any).beginMetadataSession();
 

--- a/packages/eufy-stream-server/tests/stream-server.test.ts
+++ b/packages/eufy-stream-server/tests/stream-server.test.ts
@@ -100,6 +100,60 @@ describe("StreamServer", () => {
 
       await expect(server.start()).rejects.toThrow("Server is already running");
     });
+
+    it("reinstalls WebSocket listeners after a normal stop/start", async () => {
+      const listeners: Array<{
+        event: string;
+        callback: (event: any) => void;
+      }> = [];
+      mockWsClient.addEventListener.mockImplementation(
+        (event: string, callback: (payload: any) => void) => {
+          const listener = { event, callback };
+          listeners.push(listener);
+          return () => {
+            const index = listeners.indexOf(listener);
+            if (index !== -1) listeners.splice(index, 1);
+            return index !== -1;
+          };
+        },
+      );
+
+      const restarted = new StreamServer({
+        port: testPort + 1,
+        host: "127.0.0.1",
+        wsClient: mockWsClient,
+        serialNumber: "TEST_DEVICE_123",
+      });
+      await restarted.start();
+      await restarted.stop();
+      await restarted.start();
+
+      const video = listeners.find(
+        ({ event }) => event === "livestream video data",
+      );
+      const audio = listeners.find(
+        ({ event }) => event === "livestream audio data",
+      );
+      video?.callback({
+        serialNumber: "TEST_DEVICE_123",
+        buffer: { data: createTestH264Data() },
+        metadata: {
+          videoCodec: "H264",
+          videoFPS: 15,
+          videoWidth: 1280,
+          videoHeight: 720,
+        },
+      });
+      audio?.callback({
+        serialNumber: "TEST_DEVICE_123",
+        buffer: { data: Buffer.from([0xff, 0xf1, 0x50, 0x80, 0, 0x1f, 0xfc]) },
+        metadata: { audioCodec: "AAC" },
+      });
+
+      expect(restarted.getVideoMetadata()?.videoCodec).toBe("H264");
+      expect(restarted.getAudioStatus()).toBe("aac");
+      await restarted.stop();
+    });
   });
 
   describe("client connections", () => {
@@ -165,7 +219,6 @@ describe("StreamServer", () => {
 
     it("notifies once when a muxed client attaches while pending and not again on muxer activation", async () => {
       await server.start();
-      (server as any).deliversAudio = true;
       const attached = jest.fn();
       server.onNextConsumerAttached(attached);
 
@@ -181,6 +234,7 @@ describe("StreamServer", () => {
       const videoCallback = mockWsClient.addEventListener.mock.calls.find(
         (call: any[]) => call[0] === "livestream video data",
       )[1];
+      (server as any).deliversAudio = true;
       videoCallback({
         serialNumber: "TEST_DEVICE_123",
         buffer: { data: createTestH264Data() },
@@ -1732,6 +1786,15 @@ describe("StreamServer", () => {
       expect(server.getVideoMetadata()?.videoCodec).toBe("H265");
     });
 
+    it("does not carry audio detection into a new metadata session", () => {
+      (server as any).audioMetadata = { audioCodec: "AAC" };
+
+      (server as any).beginMetadataSession();
+
+      expect(server.getAudioStatus()).toBe("unknown");
+      expect((server as any).audioMetadata).toBeNull();
+    });
+
     it("boots upstream for a metadata waiter and holds its consumer until release", async () => {
       await server.start();
 
@@ -1795,7 +1858,6 @@ describe("StreamServer", () => {
       // These tests exercise audio, so mark the device as audio-capable to
       // skip the muxer's audio-detection wait and create it immediately
       // (in "both" mode), matching the assumption these tests were written under.
-      (server as any).deliversAudio = true;
       const startCode = Buffer.from([0x00, 0x00, 0x00, 0x01]);
       // Minimal H.264 SPS NAL — content irrelevant for metadata capture.
       const nal = Buffer.from([0x67, 0x42, 0x00, 0x1e]);
@@ -1803,6 +1865,7 @@ describe("StreamServer", () => {
       // connection and issued its session start. Defer this synthetic frame
       // one event turn so it verifies that newly-started session.
       setTimeout(() => {
+        (server as any).deliversAudio = true;
         videoCallback({
           serialNumber: "TEST_DEVICE_123",
           buffer: { data: Buffer.concat([startCode, nal]) },
@@ -1985,7 +2048,6 @@ describe("StreamServer", () => {
       // Default these tests to audio-capable so the muxer is built
       // immediately (mode "both"), as they were written before audio-aware
       // mode existed. The video-only path has its own dedicated tests.
-      (s as any).deliversAudio = true;
       const videoCall = (
         (s as any).options.wsClient as any
       ).addEventListener.mock.calls.find(
@@ -1997,6 +2059,7 @@ describe("StreamServer", () => {
       // Keep the synthetic first frame after the connection handler has
       // established its metadata session, matching real P2P ordering.
       setTimeout(() => {
+        (s as any).deliversAudio = true;
         videoCallback({
           serialNumber: "TEST_DEVICE_123",
           buffer: { data: Buffer.concat([startCode, nal]) },
@@ -2154,10 +2217,6 @@ describe("StreamServer", () => {
       });
       await new Promise((resolve) => socket.on("connect", resolve));
 
-      // Known video-only: skip the audio-detection wait. (Without this the
-      // muxer would block ~2.5s waiting for an audio frame that never comes.)
-      (server as any).deliversAudio = false;
-
       // Let the connection handler establish its new metadata session before
       // simulating the first P2P video frame.
       await wait(0);
@@ -2168,6 +2227,9 @@ describe("StreamServer", () => {
       ).addEventListener.mock.calls.find(
         (call: any[]) => call[0] === "livestream video data",
       )[1];
+      // Known video-only: set this after the new session clears stale audio
+      // detection, so the muxer does not wait for a track that will not arrive.
+      (server as any).deliversAudio = false;
       videoCallback({
         serialNumber: "TEST_DEVICE_123",
         buffer: {

--- a/packages/eufy-stream-server/tests/stream-server.test.ts
+++ b/packages/eufy-stream-server/tests/stream-server.test.ts
@@ -134,6 +134,34 @@ describe("StreamServer", () => {
       expect(clientDisconnectedSpy).toHaveBeenCalledTimes(1);
       expect(server.getActiveConnectionCount()).toBe(0);
     });
+
+    it("notifies one next-consumer callback once and supports unsubscribe", async () => {
+      await server.start();
+      const attached = jest.fn();
+      const unsubscribe = server.onNextConsumerAttached(attached);
+
+      const client = net.createConnection({
+        port: testPort,
+        host: "127.0.0.1",
+      });
+      await new Promise((resolve) => client.on("connect", resolve));
+      await wait(20);
+      expect(attached).toHaveBeenCalledTimes(1);
+
+      const ignored = jest.fn();
+      const removeIgnored = server.onNextConsumerAttached(ignored);
+      removeIgnored();
+      const second = net.createConnection({
+        port: testPort,
+        host: "127.0.0.1",
+      });
+      await new Promise((resolve) => second.on("connect", resolve));
+      await wait(20);
+      expect(ignored).not.toHaveBeenCalled();
+      unsubscribe();
+      client.destroy();
+      second.destroy();
+    });
   });
 
   describe("video streaming", () => {
@@ -982,6 +1010,165 @@ describe("StreamServer", () => {
       expect(startLivestream).toHaveBeenCalled();
       await s.stop();
     });
+
+    it("holds a background slot briefly, then stops upstream before releasing it", async () => {
+      const order: string[] = [];
+      let streaming = false;
+      const deviceApi = {
+        startLivestream: jest.fn().mockImplementation(async () => {
+          streaming = true;
+        }),
+        stopLivestream: jest.fn().mockImplementation(async () => {
+          streaming = false;
+          order.push("stop");
+        }),
+        isLivestreaming: jest
+          .fn()
+          .mockImplementation(async () => ({ livestreaming: streaming })),
+      };
+      const wsClient = {
+        addEventListener: jest.fn().mockReturnValue(() => {}),
+        commands: { device: jest.fn().mockReturnValue(deviceApi) },
+      };
+      const lease = {
+        active: true,
+        whenReady: Promise.resolve(),
+        markDelivering: jest.fn(),
+        release: jest.fn(() => order.push("release")),
+      };
+      const acquireStreamSlot = jest.fn().mockReturnValue(lease);
+      const s = new StreamServer({
+        port: testPort,
+        host: "127.0.0.1",
+        wsClient: wsClient as any,
+        serialNumber: "TEST123",
+        acquireStreamSlot,
+      });
+      await s.start();
+
+      s.holdWarmLease(30);
+      await wait(20);
+      expect(acquireStreamSlot).toHaveBeenCalledWith(
+        "background",
+        expect.any(Function),
+      );
+      expect(deviceApi.startLivestream).toHaveBeenCalled();
+
+      await wait(60);
+      expect(order).toEqual(["stop", "release"]);
+      await s.stop();
+    });
+
+    it("replaces an expiring background warm slot with a live consumer lease", async () => {
+      let streaming = false;
+      const deviceApi = {
+        startLivestream: jest.fn().mockImplementation(async () => {
+          streaming = true;
+        }),
+        stopLivestream: jest.fn().mockImplementation(async () => {
+          streaming = false;
+        }),
+        isLivestreaming: jest
+          .fn()
+          .mockImplementation(async () => ({ livestreaming: streaming })),
+      };
+      const wsClient = {
+        addEventListener: jest.fn().mockReturnValue(() => {}),
+        commands: { device: jest.fn().mockReturnValue(deviceApi) },
+      };
+      const backgroundLease = {
+        active: true,
+        whenReady: Promise.resolve(),
+        markDelivering: jest.fn(),
+        release: jest.fn(),
+      };
+      const liveLease = {
+        active: true,
+        whenReady: Promise.resolve(),
+        markDelivering: jest.fn(),
+        release: jest.fn(),
+      };
+      const acquireStreamSlot = jest
+        .fn()
+        .mockReturnValueOnce(backgroundLease)
+        .mockReturnValueOnce(liveLease);
+      const s = new StreamServer({
+        port: testPort,
+        host: "127.0.0.1",
+        wsClient: wsClient as any,
+        serialNumber: "TEST123",
+        acquireStreamSlot,
+      });
+      await s.start();
+      s.holdWarmLease(80);
+      await wait(20);
+
+      const client = net.createConnection({
+        port: testPort,
+        host: "127.0.0.1",
+      });
+      await new Promise((resolve) => client.on("connect", resolve));
+      await wait(20);
+      expect(backgroundLease.release).toHaveBeenCalled();
+      expect(acquireStreamSlot).toHaveBeenLastCalledWith(
+        "live",
+        expect.any(Function),
+      );
+
+      await wait(100);
+      expect(liveLease.release).not.toHaveBeenCalled();
+      client.destroy();
+      await s.stop();
+    });
+
+    it("keeps a warm background consumer through wedge recycle and re-arms it", async () => {
+      const { mockWsClient, startLivestream } = makeWs();
+      const leases = [
+        {
+          active: true,
+          whenReady: Promise.resolve(),
+          markDelivering: jest.fn(),
+          release: jest.fn(),
+        },
+        {
+          active: true,
+          whenReady: Promise.resolve(),
+          markDelivering: jest.fn(),
+          release: jest.fn(),
+        },
+      ];
+      const acquireStreamSlot = jest
+        .fn()
+        .mockImplementation(() => leases.shift()!);
+      const s = new StreamServer({
+        port: testPort,
+        host: "127.0.0.1",
+        wsClient: mockWsClient as any,
+        serialNumber: "TEST123",
+        acquireStreamSlot,
+      });
+      await s.start();
+      s.holdWarmLease(500);
+      await wait(20);
+      expect(acquireStreamSlot).toHaveBeenLastCalledWith(
+        "background",
+        expect.any(Function),
+      );
+
+      (s as any).markUpstreamWedged("cold-start-counter-maxed", {
+        attempts: 1,
+      });
+      s.setRecycleInFlight(true);
+      s.setRecycleInFlight(false);
+      await wait(20);
+
+      expect(acquireStreamSlot).toHaveBeenLastCalledWith(
+        "background",
+        expect.any(Function),
+      );
+      expect(startLivestream).toHaveBeenCalledTimes(2);
+      await s.stop();
+    });
   });
 
   describe("keyframe cache (getCachedKeyframe)", () => {
@@ -1213,16 +1400,7 @@ describe("StreamServer", () => {
       videoListener[1]({
         serialNumber: "TEST_DEVICE_123",
         buffer: {
-          data: Buffer.from([
-            0x00,
-            0x00,
-            0x00,
-            0x01,
-            0x67,
-            0x42,
-            0x00,
-            0x1e,
-          ]),
+          data: Buffer.from([0x00, 0x00, 0x00, 0x01, 0x67, 0x42, 0x00, 0x1e]),
         },
         metadata: {
           videoCodec: codec,
@@ -1264,6 +1442,56 @@ describe("StreamServer", () => {
 
       expect(server.isMetadataVerifiedForCurrentSession()).toBe(true);
       expect(server.getVideoMetadata()?.videoCodec).toBe("H265");
+    });
+
+    it("boots upstream for a metadata waiter and holds its consumer until release", async () => {
+      await server.start();
+
+      const waiter = server.acquireMetadataWaiter(5000);
+      await wait(20);
+
+      expect((server as any).getTotalConsumers()).toBe(1);
+      expect(mockWsClient.commands.device().startLivestream).toHaveBeenCalled();
+
+      fireVideoMetadata("H265");
+      await expect(waiter.promise).resolves.toEqual(
+        expect.objectContaining({ videoCodec: "H265" }),
+      );
+      expect((server as any).getTotalConsumers()).toBe(1);
+
+      waiter.release();
+      expect((server as any).getTotalConsumers()).toBe(0);
+    });
+
+    it("cancels a metadata bootstrap cleanly and turns its timeout into a background warm lease", async () => {
+      const acquireStreamSlot = jest.fn().mockImplementation(() => ({
+        active: true,
+        whenReady: Promise.resolve(),
+        markDelivering: jest.fn(),
+        release: jest.fn(),
+      }));
+      const s = new StreamServer({
+        port: testPort + 1,
+        host: "127.0.0.1",
+        wsClient: mockWsClient,
+        serialNumber: "TEST_DEVICE_123",
+        acquireStreamSlot,
+      });
+      await s.start();
+      const cancelled = s.acquireMetadataWaiter(5000);
+      cancelled.cancel();
+      await expect(cancelled.promise).rejects.toThrow(/cancel/i);
+      expect((s as any).getTotalConsumers()).toBe(0);
+
+      const timedOut = s.acquireMetadataWaiter(20);
+      await expect(timedOut.promise).rejects.toThrow(/timeout/i);
+      await wait(20);
+      expect(acquireStreamSlot.mock.calls.map((call) => call[0])).toEqual([
+        "live",
+        "live",
+        "background",
+      ]);
+      await s.stop();
     });
   });
 
@@ -1409,6 +1637,22 @@ describe("StreamServer", () => {
         metadata: { audioCodec: "AAC" },
       });
       expect((server as any).deliversAudio).toBe(true);
+    });
+
+    it("reports unknown, aac, and video-only audio detection states", () => {
+      expect(server.getAudioStatus()).toBe("unknown");
+
+      audioCallback({
+        serialNumber: "TEST_DEVICE_123",
+        buffer: {
+          data: Buffer.from([0xff, 0xf1, 0x50, 0x80, 0x00, 0x1f, 0xfc]),
+        },
+        metadata: { audioCodec: "AAC" },
+      });
+      expect(server.getAudioStatus()).toBe("aac");
+
+      (server as any).deliversAudio = false;
+      expect(server.getAudioStatus()).toBe("none");
     });
 
     it("feeds valid ADTS frames to all muxers", async () => {

--- a/packages/eufy-stream-server/tests/stream-server.test.ts
+++ b/packages/eufy-stream-server/tests/stream-server.test.ts
@@ -1205,6 +1205,68 @@ describe("StreamServer", () => {
     });
   });
 
+  describe("metadata sessions and wait hygiene", () => {
+    const fireVideoMetadata = (codec: "H264" | "H265") => {
+      const videoListener = mockWsClient.addEventListener.mock.calls.find(
+        (call: any[]) => call[0] === "livestream video data",
+      );
+      videoListener[1]({
+        serialNumber: "TEST_DEVICE_123",
+        buffer: {
+          data: Buffer.from([
+            0x00,
+            0x00,
+            0x00,
+            0x01,
+            0x67,
+            0x42,
+            0x00,
+            0x1e,
+          ]),
+        },
+        metadata: {
+          videoCodec: codec,
+          videoFPS: 15,
+          videoWidth: 1280,
+          videoHeight: 720,
+        },
+      });
+    };
+
+    it("removes a waiter after metadata wait timeout", async () => {
+      await expect(server.waitForVideoMetadata(50)).rejects.toThrow();
+      expect((server as any).metadataWaiters.length).toBe(0);
+    });
+
+    it("removes a waiter after metadata wait cancellation", async () => {
+      const controller = new AbortController();
+      const waitForMetadata = server.waitForVideoMetadata(5000, {
+        signal: controller.signal,
+      });
+
+      controller.abort();
+
+      await expect(waitForMetadata).rejects.toThrow(/cancel/i);
+      expect((server as any).metadataWaiters.length).toBe(0);
+    });
+
+    it("requires metadata confirmation for every livestream session", () => {
+      fireVideoMetadata("H264");
+      expect(server.getVideoMetadata()?.videoCodec).toBe("H264");
+      expect(server.isMetadataVerifiedForCurrentSession()).toBe(true);
+
+      (server as any).beginMetadataSession();
+
+      expect(server.isMetadataVerifiedForCurrentSession()).toBe(false);
+      expect(server.getVideoMetadata()?.videoCodec).toBe("H264");
+
+      fireVideoMetadata("H265");
+
+      expect(server.isMetadataVerifiedForCurrentSession()).toBe(true);
+      expect(server.getVideoMetadata()?.videoCodec).toBe("H265");
+    });
+  });
+
   describe("audio event handler", () => {
     let audioCallback: (event: any) => void;
     let videoCallback: (event: any) => void;
@@ -1221,16 +1283,21 @@ describe("StreamServer", () => {
       const startCode = Buffer.from([0x00, 0x00, 0x00, 0x01]);
       // Minimal H.264 SPS NAL — content irrelevant for metadata capture.
       const nal = Buffer.from([0x67, 0x42, 0x00, 0x1e]);
-      videoCallback({
-        serialNumber: "TEST_DEVICE_123",
-        buffer: { data: Buffer.concat([startCode, nal]) },
-        metadata: {
-          videoCodec: "H264",
-          videoFPS: 30,
-          videoWidth: 1280,
-          videoHeight: 720,
-        },
-      });
+      // A real first frame cannot arrive before the server has handled the
+      // connection and issued its session start. Defer this synthetic frame
+      // one event turn so it verifies that newly-started session.
+      setTimeout(() => {
+        videoCallback({
+          serialNumber: "TEST_DEVICE_123",
+          buffer: { data: Buffer.concat([startCode, nal]) },
+          metadata: {
+            videoCodec: "H264",
+            videoFPS: 30,
+            videoWidth: 1280,
+            videoHeight: 720,
+          },
+        });
+      }, 0);
     };
 
     beforeEach(async () => {
@@ -1395,16 +1462,20 @@ describe("StreamServer", () => {
       const videoCallback = videoCall[1];
       const startCode = Buffer.from([0x00, 0x00, 0x00, 0x01]);
       const nal = Buffer.from([0x67, 0x42, 0x00, 0x1e]);
-      videoCallback({
-        serialNumber: "TEST_DEVICE_123",
-        buffer: { data: Buffer.concat([startCode, nal]) },
-        metadata: {
-          videoCodec: codec,
-          videoFPS: 30,
-          videoWidth: 1280,
-          videoHeight: 720,
-        },
-      });
+      // Keep the synthetic first frame after the connection handler has
+      // established its metadata session, matching real P2P ordering.
+      setTimeout(() => {
+        videoCallback({
+          serialNumber: "TEST_DEVICE_123",
+          buffer: { data: Buffer.concat([startCode, nal]) },
+          metadata: {
+            videoCodec: codec,
+            videoFPS: 30,
+            videoWidth: 1280,
+            videoHeight: 720,
+          },
+        });
+      }, 0);
     };
 
     it("adds muxer to map on connection", async () => {
@@ -1554,6 +1625,10 @@ describe("StreamServer", () => {
       // Known video-only: skip the audio-detection wait. (Without this the
       // muxer would block ~2.5s waiting for an audio frame that never comes.)
       (server as any).deliversAudio = false;
+
+      // Let the connection handler establish its new metadata session before
+      // simulating the first P2P video frame.
+      await wait(0);
 
       // Seed video metadata directly — the helper would force audio=true.
       const videoCallback = (

--- a/packages/eufy-stream-server/tests/stream-server.test.ts
+++ b/packages/eufy-stream-server/tests/stream-server.test.ts
@@ -162,6 +162,40 @@ describe("StreamServer", () => {
       client.destroy();
       second.destroy();
     });
+
+    it("notifies once when a muxed client attaches while pending and not again on muxer activation", async () => {
+      await server.start();
+      (server as any).deliversAudio = true;
+      const attached = jest.fn();
+      server.onNextConsumerAttached(attached);
+
+      const socket = net.createConnection({
+        port: server.getMuxedPort()!,
+        host: "127.0.0.1",
+      });
+      await new Promise((resolve) => socket.on("connect", resolve));
+      await wait(20);
+      expect((server as any).pendingMuxerSockets.size).toBe(1);
+      expect(attached).toHaveBeenCalledTimes(1);
+
+      const videoCallback = mockWsClient.addEventListener.mock.calls.find(
+        (call: any[]) => call[0] === "livestream video data",
+      )[1];
+      videoCallback({
+        serialNumber: "TEST_DEVICE_123",
+        buffer: { data: createTestH264Data() },
+        metadata: {
+          videoCodec: "H264",
+          videoFPS: 15,
+          videoWidth: 1280,
+          videoHeight: 720,
+        },
+      });
+      await wait(20);
+      expect((server as any).muxerStreams.size).toBe(1);
+      expect(attached).toHaveBeenCalledTimes(1);
+      socket.destroy();
+    });
   });
 
   describe("video streaming", () => {
@@ -1056,6 +1090,196 @@ describe("StreamServer", () => {
 
       await wait(60);
       expect(order).toEqual(["stop", "release"]);
+      await s.stop();
+    });
+
+    it("stops and releases a live grant before a denied warm background retry", async () => {
+      const order: string[] = [];
+      let streaming = false;
+      const deviceApi = {
+        startLivestream: jest.fn().mockImplementation(async () => {
+          streaming = true;
+        }),
+        stopLivestream: jest.fn().mockImplementation(async () => {
+          streaming = false;
+          order.push("stop");
+        }),
+        isLivestreaming: jest
+          .fn()
+          .mockImplementation(async () => ({ livestreaming: streaming })),
+      };
+      const wsClient = {
+        addEventListener: jest.fn().mockReturnValue(() => {}),
+        commands: { device: jest.fn().mockReturnValue(deviceApi) },
+      };
+      const liveLease = {
+        active: true,
+        whenReady: Promise.resolve(),
+        markDelivering: jest.fn(),
+        release: jest.fn(() => order.push("release")),
+      };
+      const acquireStreamSlot = jest
+        .fn()
+        .mockReturnValueOnce(liveLease)
+        .mockImplementationOnce(() => {
+          order.push("background-denied");
+          return null;
+        });
+      const s = new StreamServer({
+        port: testPort,
+        host: "127.0.0.1",
+        wsClient: wsClient as any,
+        serialNumber: "TEST123",
+        acquireStreamSlot,
+      });
+      await s.start();
+      const bootstrap = s.acquireMetadataWaiter(5000);
+      await wait(20);
+      expect(acquireStreamSlot).toHaveBeenLastCalledWith(
+        "live",
+        expect.any(Function),
+      );
+
+      s.holdWarmLease(500);
+      await wait(30);
+
+      expect(order).toEqual(["stop", "release", "background-denied"]);
+      expect((s as any).livestreamIntendedState).toBe(false);
+      expect((s as any).streamLease).toBeNull();
+      void bootstrap.promise.catch(() => {});
+      bootstrap.release();
+      await s.stop();
+    });
+
+    it("does not create a warm lease for a real consumer and ignores duplicate holds", async () => {
+      const { mockWsClient } = makeWs();
+      const acquireStreamSlot = jest.fn().mockReturnValue({
+        active: true,
+        whenReady: Promise.resolve(),
+        markDelivering: jest.fn(),
+        release: jest.fn(),
+      });
+      const s = new StreamServer({
+        port: testPort,
+        host: "127.0.0.1",
+        wsClient: mockWsClient as any,
+        serialNumber: "TEST123",
+        acquireStreamSlot,
+      });
+      await s.start();
+      const client = net.createConnection({
+        port: testPort,
+        host: "127.0.0.1",
+      });
+      await new Promise((resolve) => client.on("connect", resolve));
+      await wait(20);
+
+      s.holdWarmLease(500);
+      expect((s as any).warmLease).toBeUndefined();
+      client.destroy();
+
+      const isolated = new StreamServer({
+        port: testPort + 1,
+        host: "127.0.0.1",
+        wsClient: mockWsClient as any,
+        serialNumber: "TEST124",
+        acquireStreamSlot,
+      });
+      await isolated.start();
+      isolated.holdWarmLease(500);
+      isolated.holdWarmLease(500);
+      await wait(20);
+      expect((isolated as any).metadataBootstrapConsumers).toBe(1);
+      await isolated.stop();
+      await s.stop();
+    });
+
+    it("ends a warm lease on its first live frame", async () => {
+      const { mockWsClient } = makeWs();
+      let streaming = false;
+      const deviceApi = mockWsClient.commands.device();
+      deviceApi.startLivestream.mockImplementation(async () => {
+        streaming = true;
+      });
+      deviceApi.stopLivestream.mockImplementation(async () => {
+        streaming = false;
+      });
+      deviceApi.isLivestreaming = jest.fn(async () => ({
+        livestreaming: streaming,
+      }));
+      const acquireStreamSlot = jest.fn().mockReturnValue({
+        active: true,
+        whenReady: Promise.resolve(),
+        markDelivering: jest.fn(),
+        release: jest.fn(),
+      });
+      const s = new StreamServer({
+        port: testPort,
+        host: "127.0.0.1",
+        wsClient: mockWsClient as any,
+        serialNumber: "TEST123",
+        acquireStreamSlot,
+      });
+      await s.start();
+      s.holdWarmLease(500);
+      await wait(20);
+      const videoCallback = mockWsClient.addEventListener.mock.calls.find(
+        (call: any[]) => call[0] === "livestream video data",
+      )[1];
+      videoCallback({
+        serialNumber: "TEST123",
+        buffer: { data: createTestH264Data() },
+        metadata: {
+          videoCodec: "H264",
+          videoFPS: 15,
+          videoWidth: 1280,
+          videoHeight: 720,
+        },
+      });
+      await wait(20);
+      expect((s as any).warmLease).toBeUndefined();
+      expect(deviceApi.stopLivestream).toHaveBeenCalled();
+      await s.stop();
+    });
+
+    it("ends a warm lease when a sibling preempts its background slot", async () => {
+      const { mockWsClient } = makeWs();
+      let revoke: (() => void) | undefined;
+      let streaming = false;
+      const deviceApi = mockWsClient.commands.device();
+      deviceApi.startLivestream.mockImplementation(async () => {
+        streaming = true;
+      });
+      deviceApi.stopLivestream.mockImplementation(async () => {
+        streaming = false;
+      });
+      deviceApi.isLivestreaming = jest.fn(async () => ({
+        livestreaming: streaming,
+      }));
+      const lease = {
+        active: true,
+        whenReady: Promise.resolve(),
+        markDelivering: jest.fn(),
+        release: jest.fn(),
+      };
+      const s = new StreamServer({
+        port: testPort,
+        host: "127.0.0.1",
+        wsClient: mockWsClient as any,
+        serialNumber: "TEST123",
+        acquireStreamSlot: jest.fn((_priority, onRevoke) => {
+          revoke = onRevoke;
+          return lease;
+        }),
+      });
+      await s.start();
+      s.holdWarmLease(500);
+      await wait(20);
+      revoke!();
+      await wait(20);
+      expect((s as any).warmLease).toBeUndefined();
+      expect(deviceApi.stopLivestream).toHaveBeenCalled();
+      expect(lease.release).toHaveBeenCalled();
       await s.stop();
     });
 

--- a/packages/eufy-stream-server/tests/stream-server.test.ts
+++ b/packages/eufy-stream-server/tests/stream-server.test.ts
@@ -1683,15 +1683,34 @@ describe("StreamServer", () => {
         port: server.getMuxedPort()!,
         host: "127.0.0.1",
       });
-      await new Promise((resolve) => socket.on("connect", resolve));
-      await wait(20);
+      const unhandledRejections: unknown[] = [];
+      const onUnhandledRejection = (reason: unknown) => {
+        unhandledRejections.push(reason);
+      };
+      process.on("unhandledRejection", onUnhandledRejection);
 
-      expect((server as any).metadataWaiters.length).toBe(1);
+      try {
+        await new Promise((resolve) => socket.on("connect", resolve));
+        await wait(20);
 
-      socket.destroy();
-      await wait(20);
+        expect((server as any).metadataWaiters.length).toBe(1);
 
-      expect((server as any).metadataWaiters.length).toBe(0);
+        const pendingServerSocket = Array.from(
+          (server as any).pendingMuxerSockets,
+        )[0] as net.Socket;
+        const serverSocketClosed = new Promise<void>((resolve) =>
+          pendingServerSocket.once("close", resolve),
+        );
+        socket.destroy();
+        await serverSocketClosed;
+        await Promise.resolve();
+
+        expect((server as any).metadataWaiters.length).toBe(0);
+        expect(unhandledRejections).toEqual([]);
+      } finally {
+        process.removeListener("unhandledRejection", onUnhandledRejection);
+        socket.destroy();
+      }
     });
 
     it("cancels pending metadata waits before server stop resolves", async () => {
@@ -1701,15 +1720,27 @@ describe("StreamServer", () => {
         port: server.getMuxedPort()!,
         host: "127.0.0.1",
       });
-      await new Promise((resolve) => socket.on("connect", resolve));
-      await wait(20);
+      const unhandledRejections: unknown[] = [];
+      const onUnhandledRejection = (reason: unknown) => {
+        unhandledRejections.push(reason);
+      };
+      process.on("unhandledRejection", onUnhandledRejection);
 
-      expect((server as any).metadataWaiters.length).toBe(1);
+      try {
+        await new Promise((resolve) => socket.on("connect", resolve));
+        await wait(20);
 
-      await server.stop();
+        expect((server as any).metadataWaiters.length).toBe(1);
 
-      expect((server as any).metadataWaiters.length).toBe(0);
-      socket.destroy();
+        await server.stop();
+        await Promise.resolve();
+
+        expect((server as any).metadataWaiters.length).toBe(0);
+        expect(unhandledRejections).toEqual([]);
+      } finally {
+        process.removeListener("unhandledRejection", onUnhandledRejection);
+        socket.destroy();
+      }
     });
 
     it("JMuxer duplex data is written to socket", async () => {

--- a/packages/eufy-stream-server/tests/stream-server.test.ts
+++ b/packages/eufy-stream-server/tests/stream-server.test.ts
@@ -1393,6 +1393,70 @@ describe("StreamServer", () => {
       expect(startLivestream).toHaveBeenCalledTimes(2);
       await s.stop();
     });
+
+    it("stops before releasing a wedged warm slot, then re-arms it after recycle", async () => {
+      const order: string[] = [];
+      let streaming = false;
+      const deviceApi = {
+        startLivestream: jest.fn().mockImplementation(async () => {
+          streaming = true;
+        }),
+        stopLivestream: jest.fn().mockImplementation(async () => {
+          streaming = false;
+          order.push("stop");
+        }),
+        isLivestreaming: jest
+          .fn()
+          .mockImplementation(async () => ({ livestreaming: streaming })),
+      };
+      const wsClient = {
+        addEventListener: jest.fn().mockReturnValue(() => {}),
+        commands: { device: jest.fn().mockReturnValue(deviceApi) },
+      };
+      const leases = [
+        {
+          active: true,
+          whenReady: Promise.resolve(),
+          markDelivering: jest.fn(),
+          release: jest.fn(() => order.push("release")),
+        },
+        {
+          active: true,
+          whenReady: Promise.resolve(),
+          markDelivering: jest.fn(),
+          release: jest.fn(),
+        },
+      ];
+      const acquireStreamSlot = jest
+        .fn()
+        .mockImplementation(() => leases.shift()!);
+      const s = new StreamServer({
+        port: testPort,
+        host: "127.0.0.1",
+        wsClient: wsClient as any,
+        serialNumber: "TEST123",
+        acquireStreamSlot,
+      });
+      await s.start();
+      s.holdWarmLease(500);
+      await wait(20);
+
+      (s as any).markUpstreamWedged("cold-start-counter-maxed", {
+        attempts: 1,
+      });
+      await wait(20);
+      expect(order).toEqual(["stop", "release"]);
+
+      s.setRecycleInFlight(true);
+      s.setRecycleInFlight(false);
+      await wait(20);
+      expect(acquireStreamSlot).toHaveBeenLastCalledWith(
+        "background",
+        expect.any(Function),
+      );
+      expect(deviceApi.startLivestream).toHaveBeenCalledTimes(2);
+      await s.stop();
+    });
   });
 
   describe("keyframe cache (getCachedKeyframe)", () => {

--- a/packages/eufy-stream-server/tests/stream-server.test.ts
+++ b/packages/eufy-stream-server/tests/stream-server.test.ts
@@ -1676,6 +1676,24 @@ describe("StreamServer", () => {
       socket.destroy();
     });
 
+    it("cancels a pending metadata wait when its muxed socket closes", async () => {
+      await server.start();
+
+      const socket = net.createConnection({
+        port: server.getMuxedPort()!,
+        host: "127.0.0.1",
+      });
+      await new Promise((resolve) => socket.on("connect", resolve));
+      await wait(20);
+
+      expect((server as any).metadataWaiters.length).toBe(1);
+
+      socket.destroy();
+      await wait(20);
+
+      expect((server as any).metadataWaiters.length).toBe(0);
+    });
+
     it("JMuxer duplex data is written to socket", async () => {
       await server.start();
 

--- a/packages/eufy-stream-server/tests/stream-server.test.ts
+++ b/packages/eufy-stream-server/tests/stream-server.test.ts
@@ -1703,7 +1703,7 @@ describe("StreamServer", () => {
         );
         socket.destroy();
         await serverSocketClosed;
-        await Promise.resolve();
+        await new Promise<void>((resolve) => setImmediate(resolve));
 
         expect((server as any).metadataWaiters.length).toBe(0);
         expect(unhandledRejections).toEqual([]);
@@ -1733,7 +1733,7 @@ describe("StreamServer", () => {
         expect((server as any).metadataWaiters.length).toBe(1);
 
         await server.stop();
-        await Promise.resolve();
+        await new Promise<void>((resolve) => setImmediate(resolve));
 
         expect((server as any).metadataWaiters.length).toBe(0);
         expect(unhandledRejections).toEqual([]);

--- a/packages/eufy-stream-server/tests/thermal-governor.test.ts
+++ b/packages/eufy-stream-server/tests/thermal-governor.test.ts
@@ -1,0 +1,132 @@
+import { ThermalGovernor } from "../src/thermal-governor";
+
+describe("ThermalGovernor", () => {
+  it("throttles new compatibility encoder admissions at and above the critical temperature", async () => {
+    const governor = new ThermalGovernor({
+      temperatureReader: async () => 80,
+      criticalTemperatureC: 80,
+      recoveryTemperatureC: 70,
+    });
+
+    await governor.refresh();
+
+    expect(governor.canAdmitCompatibilityEncoder()).toBe(false);
+    expect(governor.getStatus()).toMatchObject({
+      throttled: true,
+      reason: "critical-temperature",
+      temperatureC: 80,
+    });
+  });
+
+  it("keeps throttling until the temperature reaches the recovery threshold", async () => {
+    const temperatures = [80, 75, 70];
+    const governor = new ThermalGovernor({
+      temperatureReader: async () => temperatures.shift(),
+      criticalTemperatureC: 80,
+      recoveryTemperatureC: 70,
+    });
+
+    await governor.refresh();
+    expect(governor.canAdmitCompatibilityEncoder()).toBe(false);
+
+    await governor.refresh();
+    expect(governor.canAdmitCompatibilityEncoder()).toBe(false);
+    expect(governor.getStatus().reason).toBe("above-recovery-temperature");
+
+    await governor.refresh();
+    expect(governor.canAdmitCompatibilityEncoder()).toBe(true);
+    expect(governor.getStatus()).toMatchObject({
+      throttled: false,
+      reason: "recovered",
+      temperatureC: 70,
+    });
+  });
+
+  it("is inert when temperature readings are unsupported", async () => {
+    const governor = new ThermalGovernor({
+      temperatureReader: async () => undefined,
+    });
+
+    await governor.refresh();
+
+    expect(governor.canAdmitCompatibilityEncoder()).toBe(true);
+    expect(governor.getStatus()).toEqual({
+      throttled: false,
+      reason: "unsupported",
+    });
+  });
+
+  it("is inert when the temperature reader errors", async () => {
+    const governor = new ThermalGovernor({
+      temperatureReader: async () => {
+        throw new Error("sensor unavailable");
+      },
+    });
+
+    await governor.refresh();
+
+    expect(governor.canAdmitCompatibilityEncoder()).toBe(true);
+    expect(governor.getStatus()).toEqual({
+      throttled: false,
+      reason: "read-error",
+    });
+  });
+
+  it("shares an in-flight sampled admission check", async () => {
+    let reads = 0;
+    let releaseReading: (temperature: number) => void = () => undefined;
+    const reading = new Promise<number>((resolve) => {
+      releaseReading = resolve;
+    });
+    const governor = new ThermalGovernor({
+      temperatureReader: () => {
+        reads += 1;
+        return reading;
+      },
+    });
+
+    const first = governor.refresh();
+    const second = governor.refresh();
+    releaseReading(65);
+    await Promise.all([first, second]);
+
+    expect(reads).toBe(1);
+  });
+
+  it("samples on compatibility admissions only after the configured interval", async () => {
+    let now = 1_000;
+    const temperatures = [75, 80];
+    const reader = jest.fn(async () => temperatures.shift());
+    const governor = new ThermalGovernor({
+      temperatureReader: reader,
+      criticalTemperatureC: 80,
+      recoveryTemperatureC: 70,
+      samplingIntervalMs: 100,
+      now: () => now,
+    });
+
+    await expect(governor.checkCompatibilityEncoderAdmission()).resolves.toBe(
+      true,
+    );
+    now += 99;
+    await expect(governor.checkCompatibilityEncoderAdmission()).resolves.toBe(
+      true,
+    );
+    now += 1;
+    await expect(governor.checkCompatibilityEncoderAdmission()).resolves.toBe(
+      false,
+    );
+
+    expect(reader).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    [{ criticalTemperatureC: 70, recoveryTemperatureC: 70 }],
+    [{ criticalTemperatureC: 70, recoveryTemperatureC: 71 }],
+    [{ criticalTemperatureC: Number.NaN }],
+    [{ recoveryTemperatureC: Number.POSITIVE_INFINITY }],
+    [{ samplingIntervalMs: -1 }],
+  ])("rejects invalid configuration: %o", (options) => {
+    expect(() => new ThermalGovernor(options)).toThrow();
+  });
+});

--- a/packages/eufy-stream-server/tests/thermal-governor.test.ts
+++ b/packages/eufy-stream-server/tests/thermal-governor.test.ts
@@ -93,6 +93,26 @@ describe("ThermalGovernor", () => {
     expect(reads).toBe(1);
   });
 
+  it("waits for an in-flight admission sample before returning an admission decision", async () => {
+    let releaseReading: (temperature: number) => void = () => undefined;
+    const reading = new Promise<number>((resolve) => {
+      releaseReading = resolve;
+    });
+    const governor = new ThermalGovernor({
+      temperatureReader: () => reading,
+      criticalTemperatureC: 80,
+      recoveryTemperatureC: 70,
+    });
+
+    const firstAdmission = governor.checkCompatibilityEncoderAdmission();
+    const concurrentAdmission = governor.checkCompatibilityEncoderAdmission();
+    releaseReading(80);
+
+    await expect(
+      Promise.all([firstAdmission, concurrentAdmission]),
+    ).resolves.toEqual([false, false]);
+  });
+
   it("samples on compatibility admissions only after the configured interval", async () => {
     let now = 1_000;
     const temperatures = [75, 80];


### PR DESCRIPTION
## Summary
- add a shared, bounded H.265-to-H.264 fMP4 compatibility relay with truthful stream selection, codec bootstrap, thermal admission, and lifecycle safeguards
- add Scrypted camera/provider controls, codec hint persistence, and routing that keeps recorder/native paths untouched
- add parser, pool, FFmpeg integration coverage, CI encoder checks, and compatibility documentation

## Validation
- npm run build
- npm run test
- npm run lint
- npm run format:check
- real FFmpeg HEVC-to-H.264 relay integration and late-consumer replay test