### PR TITLE
fix: treat device_livestream_already_running on start as success

### DIFF
--- a/packages/eufy-stream-server/src/stream-server.ts
+++ b/packages/eufy-stream-server/src/stream-server.ts
@@ -1390,6 +1390,27 @@ export class StreamServer extends EventEmitter {
           break;
         }
 
+        // Symmetric to the above: our pre-flight isLivestreaming() check can
+        // return a stale "false" while the server actually has the stream
+        // running (a state desync seen when switching cameras on a shared
+        // HomeBase). startLivestream then rejects with "already running".
+        // That's the stream we want — treat it as success rather than
+        // retrying, which only churns the HomeBase's single P2P slot and
+        // escalates to a spurious wedge/recycle. Mirror the "already running"
+        // status branch: anchor the session (so the mid-session wedge watchdog
+        // still fires if no data ever arrives) but do NOT force actualState
+        // true — that's driven by real video data.
+        if (msg.includes("device_livestream_already_running")) {
+          this.logger.info(
+            "Livestream already running upstream (stale status check) — treating as success",
+          );
+          if (this.livestreamSessionStartedAt === 0) {
+            this.livestreamSessionStartedAt = Date.now();
+          }
+          this.consecutiveNoDataStarts = 0;
+          break;
+        }
+
         this.logger.warn(
           `❌ Livestream command failed (attempt ${attempt}/${maxRetries}):`,
           error.message || error,

--- a/packages/eufy-stream-server/tests/stream-server.test.ts
+++ b/packages/eufy-stream-server/tests/stream-server.test.ts
@@ -2496,4 +2496,55 @@ describe("StreamServer", () => {
       socket.destroy();
     });
   });
+
+  describe("livestream state-desync error handling", () => {
+    it("treats device_livestream_already_running on start as success (no retry churn / no wedge)", async () => {
+      // The pre-flight isLivestreaming() check can return a stale "false"
+      // while the server actually has the stream running; startLivestream then
+      // rejects with "already running". That must be treated as success (the
+      // stream we want IS up) — not retried, which would churn the HomeBase's
+      // single P2P slot and escalate to a spurious wedge/recycle.
+      jest.useFakeTimers();
+      const startLivestream = jest
+        .fn()
+        .mockRejectedValue(
+          new Error("Command failed: device_livestream_already_running"),
+        );
+      const deviceApi = {
+        startLivestream,
+        stopLivestream: jest.fn().mockResolvedValue({}),
+        isLivestreaming: jest.fn().mockResolvedValue({ livestreaming: false }),
+      };
+      const wsClient = {
+        addEventListener: jest.fn().mockReturnValue(() => {}),
+        commands: { device: jest.fn().mockReturnValue(deviceApi) },
+      };
+      const s = new StreamServer({
+        port: testPort,
+        host: "127.0.0.1",
+        wsClient: wsClient as any,
+        serialNumber: "TEST123",
+      });
+      const streamErrors: unknown[] = [];
+      const wedges: unknown[] = [];
+      s.on("streamError", (e) => streamErrors.push(e));
+      s.on("upstreamWedged", (e) => wedges.push(e));
+
+      // Drive ensureLivestreamState directly (no TCP server needed).
+      (s as any).livestreamIntendedState = true;
+      const p = (s as any).ensureLivestreamState();
+      // Fast-forward well past the retry window (retryDelay 5s × 2).
+      await jest.advanceTimersByTimeAsync(12000);
+      await p;
+
+      // Exactly one start attempt, no failure escalation, session anchored so
+      // the mid-session wedge watchdog can still fire if no data arrives.
+      expect(startLivestream).toHaveBeenCalledTimes(1);
+      expect(streamErrors).toHaveLength(0);
+      expect(wedges).toHaveLength(0);
+      expect((s as any).livestreamSessionStartedAt).toBeGreaterThan(0);
+
+      jest.useRealTimers();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes a livestream state-desync bug surfaced by @jeepster5 in #7 (`LivestreamAlreadyRunningError` during E340/T8400 camera switching on a shared HomeBase).

`ensureLivestreamState()` does a pre-flight `isLivestreaming()` check before starting. That check can return a stale `false` while the server actually has the stream running — a state desync that shows up when switching between cameras on the same HomeBase (one P2P slot). The plugin then calls `startLivestream`, the server rejects with `device_livestream_already_running`, and the catch block **had no handler for it** — so it was treated as a retryable failure: 3 × 5s retries, then a spurious wedge/recycle escalation that churns the HomeBase's single P2P slot.

There was already a symmetric handler for the opposite case (`device_livestream_not_running` when stopping → treated as success). This adds the missing start-side twin.

## Fix

In the `ensureLivestreamState` catch block, when the error is `device_livestream_already_running`:
- treat it as success (the stream we want **is** up),
- anchor `livestreamSessionStartedAt` so the mid-session wedge watchdog **still fires** if no data ever arrives (deliberately **not** forcing `livestreamActualState = true`, which would suppress wedge detection — that flag is driven by real video data),
- reset the cold-start counter and `break` instead of retrying.

## Tests

New test `treats device_livestream_already_running on start as success (no retry churn / no wedge)` — **fails on the old code** (escalates to a spurious `streamError`), **passes with the fix**. Full suites green: stream-server 165, scrypted 274, lint + format.

## Scope

This addresses the `already_running` churn only. The black-live-view / no-P2P-frames symptom in #7 is being diagnosed separately (pending debug logs) and may be independent of this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)